### PR TITLE
Fix persistence probe reporting

### DIFF
--- a/src/Akka.HealthCheck.Hosting.Web/Probes/AkkaPersistenceLivenessProbe.cs
+++ b/src/Akka.HealthCheck.Hosting.Web/Probes/AkkaPersistenceLivenessProbe.cs
@@ -53,7 +53,7 @@ namespace Akka.HealthCheck.Hosting.Web.Probes
                         ["journal-recovered"] = status.JournalRecovered,
                         ["snapshot-recovered"] = status.SnapshotRecovered,
                         ["journal-persisted"] = status.JournalPersisted,
-                        ["snapshot-persisted"] = status.SnapshotPersisted,
+                        ["snapshot-persisted"] = status.SnapshotSaved,
                         ["message"] = status.StatusMessage
                     })
                     : HealthCheckResult.Unhealthy(UnHealthy, status.Failures, new Dictionary<string, object>
@@ -61,7 +61,7 @@ namespace Akka.HealthCheck.Hosting.Web.Probes
                         ["journal-recovered"] = status.JournalRecovered,
                         ["snapshot-recovered"] = status.SnapshotRecovered,
                         ["journal-persisted"] = status.JournalPersisted,
-                        ["snapshot-persisted"] = status.SnapshotPersisted,
+                        ["snapshot-persisted"] = status.SnapshotSaved,
                         ["message"] = status.StatusMessage
                     });
             }

--- a/src/Akka.HealthCheck.Persistence.Tests/Akka.HealthCheck.Persistence.Tests.csproj
+++ b/src/Akka.HealthCheck.Persistence.Tests/Akka.HealthCheck.Persistence.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="akka.persistence.sqlite" Version="$(AkkaVersion)" />
+    <PackageReference Include="Akka.Persistence.TestKit.Xunit2" Version="$(AkkaVersion)" />
     <PackageReference Include="Akka.TestKit.Xunit" Version="$(AkkaVersion)" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />

--- a/src/Akka.HealthCheck.Persistence.Tests/ProbeFailureSpec.cs
+++ b/src/Akka.HealthCheck.Persistence.Tests/ProbeFailureSpec.cs
@@ -1,0 +1,252 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ProbeFailureSpec.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2022 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Persistence.TestKit;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.HealthCheck.Persistence.Tests
+{
+    public class ProbeFailureSpec: PersistenceTestKit
+    {
+        private readonly string _id = Guid.NewGuid().ToString("N");
+        private int _count;
+        
+        public ProbeFailureSpec(ITestOutputHelper output) : base(nameof(ProbeFailureSpec), output)
+        {
+        }
+
+        [Fact(DisplayName = "First probe should report that probe is still warming up")]
+        public void SuccessfulFirstProbeTest()
+        {
+            var status = PerformProbe(); 
+            status.IsLive.Should().BeFalse();
+            status.JournalRecovered.Should().BeFalse();
+            status.JournalPersisted.Should().BeTrue();
+            status.SnapshotRecovered.Should().BeFalse();
+            status.SnapshotSaved.Should().BeTrue();
+            status.StatusMessage.Should().StartWith("Warming up probe.");
+            status.Failures.Should().BeNull();
+        }
+        
+        [Fact(DisplayName = "Status should reflect successful probe")]
+        public void SuccessfulProbeTest()
+        {
+            AssertFirstProbe();
+            var status = PerformProbe();
+            status.IsLive.Should().BeTrue();
+            status.JournalRecovered.Should().BeTrue();
+            status.JournalPersisted.Should().BeTrue();
+            status.SnapshotRecovered.Should().BeTrue();
+            status.SnapshotSaved.Should().BeTrue();
+            status.Failures.Should().BeNull();
+        }
+        
+        [Fact(DisplayName = "Journal persist failed on first probe, snapshot should still be reported as saved")]
+        public async Task JournalPersistFailOnFirstTest()
+        {
+            await WithJournalWrite(write => write.Fail(), () =>
+            {
+                var status = PerformProbe();
+                status.IsLive.Should().BeFalse();
+                status.JournalRecovered.Should().BeFalse();
+                status.JournalPersisted.Should().BeFalse();
+                status.SnapshotRecovered.Should().BeFalse();
+                status.SnapshotSaved.Should().BeTrue();
+                var e = status.Failures!.Flatten().InnerExceptions[0];
+                e.Should().BeOfType<TestJournalFailureException>();
+                status.StatusMessage.Should().NotStartWith("Warming up probe.");
+            });
+        }
+        
+        [Fact(DisplayName = "Journal persist rejected on first probe, snapshot should still be reported as saved")]
+        public async Task JournalPersistRejectedOnFirstTest()
+        {
+            await WithJournalWrite(write => write.Reject(), () =>
+            {
+                var status = PerformProbe();
+                status.IsLive.Should().BeFalse();
+                status.JournalRecovered.Should().BeFalse();
+                status.JournalPersisted.Should().BeFalse();
+                status.SnapshotRecovered.Should().BeFalse();
+                status.SnapshotSaved.Should().BeTrue();
+                var e = status.Failures!.Flatten().InnerExceptions[0];
+                e.Should().BeOfType<TestJournalRejectionException>();
+                status.StatusMessage.Should().NotStartWith("Warming up probe.");
+            });
+        }
+        
+        [Fact(DisplayName = "Snapshot failed to save on first probe, journal should still be reported as persisted")]
+        public async Task SnapshotSaveFailOnFirstTest()
+        {
+            await WithSnapshotSave(save => save.Fail(), () =>
+            {
+                var status = PerformProbe();
+                status.IsLive.Should().BeFalse();
+                status.JournalRecovered.Should().BeFalse();
+                status.JournalPersisted.Should().BeTrue();
+                status.SnapshotRecovered.Should().BeFalse();
+                status.SnapshotSaved.Should().BeFalse();
+                var e = status.Failures!.Flatten().InnerExceptions[0];
+                e.Should().BeOfType<TestSnapshotStoreFailureException>();
+                status.StatusMessage.Should().NotStartWith("Warming up probe.");
+            });
+        }
+        
+        [Fact(DisplayName = "Journal recovery failed, snapshot should still be reported as recovered")]
+        public async Task JournalRecoverFailTest()
+        {
+            AssertFirstProbe();
+            await WithJournalRecovery(recover => recover.Fail(), () =>
+            {
+                var status = PerformProbe();
+                status.IsLive.Should().BeFalse();
+                status.JournalRecovered.Should().BeFalse();
+                status.JournalPersisted.Should().BeFalse();
+                status.SnapshotRecovered.Should().BeTrue();
+                status.SnapshotSaved.Should().BeFalse();
+                var e = status.Failures!.Flatten().InnerExceptions[0];
+                e.Should().BeOfType<TestJournalFailureException>();
+            });
+        }
+
+        [Fact(DisplayName = "Snapshot recovery failed, journal should not be recovered")]
+        public async Task SnapshotRecoverFailTest()
+        {
+            AssertFirstProbe();
+            await WithSnapshotLoad(load => load.Fail(), () =>
+            {
+                var status = PerformProbe();
+                status.IsLive.Should().BeFalse();
+                status.JournalRecovered.Should().BeFalse();
+                status.JournalPersisted.Should().BeFalse();
+                status.SnapshotRecovered.Should().BeFalse();
+                status.SnapshotSaved.Should().BeFalse();
+                var e = status.Failures!.Flatten().InnerExceptions[0];
+                e.Should().BeOfType<TestSnapshotStoreFailureException>();
+            });
+        }
+        
+        [Fact(DisplayName = "Journal failed to persist, snapshot should still be reported as saved")]
+        public async Task JournalPersistFailTest()
+        {
+            AssertFirstProbe();
+            await WithJournalWrite(write => write.Fail(), () =>
+            {
+                var status = PerformProbe();
+                status.IsLive.Should().BeFalse();
+                status.JournalRecovered.Should().BeTrue();
+                status.JournalPersisted.Should().BeFalse();
+                status.SnapshotRecovered.Should().BeTrue();
+                status.SnapshotSaved.Should().BeTrue();
+                var e = status.Failures!.Flatten().InnerExceptions[0];
+                e.Should().BeOfType<TestJournalFailureException>();
+            });
+        }
+
+        [Fact(DisplayName = "Journal persist rejected, snapshot should still be reported as saved")]
+        public async Task JournalPersistRejectedTest()
+        {
+            AssertFirstProbe();
+            await WithJournalWrite(write => write.Reject(), () =>
+            {
+                var status = PerformProbe();
+                status.IsLive.Should().BeFalse();
+                status.JournalRecovered.Should().BeTrue();
+                status.JournalPersisted.Should().BeFalse();
+                status.SnapshotRecovered.Should().BeTrue();
+                status.SnapshotSaved.Should().BeTrue();
+                var e = status.Failures!.Flatten().InnerExceptions[0];
+                e.Should().BeOfType<TestJournalRejectionException>();
+            });
+        }
+
+        [Fact(DisplayName = "Snapshot failed to save, journal should still be reported as saved")]
+        public async Task SnapshotSaveFailTest()
+        {
+            AssertFirstProbe();
+            await WithSnapshotSave(write => write.Fail(), () =>
+            {
+                var status = PerformProbe();
+                status.IsLive.Should().BeFalse();
+                status.JournalRecovered.Should().BeTrue();
+                status.JournalPersisted.Should().BeTrue();
+                status.SnapshotRecovered.Should().BeTrue();
+                status.SnapshotSaved.Should().BeFalse();
+                var e = status.Failures!.Flatten().InnerExceptions[0];
+                e.Should().BeOfType<TestSnapshotStoreFailureException>();
+            });
+        }
+
+        [Fact(DisplayName = "Snapshot delete failed, everything should be true with exception")]
+        public async Task SnapshotDeleteFailTest()
+        {
+            AssertFirstProbe();
+            await WithSnapshotDelete(delete => delete.Fail(), () =>
+            {
+                var status = PerformProbe();
+                status.IsLive.Should().BeFalse();
+                status.JournalRecovered.Should().BeTrue();
+                status.JournalPersisted.Should().BeTrue();
+                status.SnapshotRecovered.Should().BeTrue();
+                status.SnapshotSaved.Should().BeTrue();
+                var e = status.Failures!.Flatten().InnerExceptions[0];
+                e.Should().BeOfType<TestSnapshotStoreFailureException>();
+            });
+        }
+        
+        // Could not test journal delete failed test, TestJournal does not expose journal delete behavior
+        /*
+        [Fact(DisplayName = "Journal delete failed, everything should be true with exception")]
+        public async Task JournalDeleteFailTest()
+        {
+            AssertFirstProbe();
+            await WithJournalDelete(delete => delete.Fail(), () =>
+            {
+                var status = PerformProbe();
+                status.IsLive.Should().BeFalse();
+                status.JournalRecovered.Should().BeTrue();
+                status.JournalPersisted.Should().BeTrue();
+                status.SnapshotRecovered.Should().BeTrue();
+                status.SnapshotSaved.Should().BeTrue();
+                var e = status.Failures!.Flatten().InnerExceptions[0];
+                e.Should().BeOfType<TestSnapshotStoreFailureException>();
+            });
+        }
+        */
+
+        private PersistenceLivenessStatus PerformProbe()
+        {
+            _count++;
+            var liveProbe = ActorOf(() => new SuicideProbe(TestActor, _count == 1, _id));
+            Watch(liveProbe);
+            liveProbe.Tell($"hit-{_count}");
+            var status = ExpectMsg<PersistenceLivenessStatus>();
+            ExpectTerminated(liveProbe);
+            Unwatch(liveProbe);
+
+            return status;
+        }
+        
+        private void AssertFirstProbe()
+        {
+            if (_count != 0)
+                throw new Exception("Must be called as the first probe!");
+            
+            var status = PerformProbe(); 
+            status.JournalRecovered.Should().BeFalse();
+            status.JournalPersisted.Should().BeTrue();
+            status.SnapshotRecovered.Should().BeFalse();
+            status.SnapshotSaved.Should().BeTrue();
+            status.StatusMessage.Should().StartWith("Warming up probe.");
+            status.Failures.Should().BeNull();
+        }
+    }
+}

--- a/src/Akka.HealthCheck.Persistence/Akka.HealthCheck.Persistence.csproj
+++ b/src/Akka.HealthCheck.Persistence/Akka.HealthCheck.Persistence.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
     <Description>Akka.NET and Akka.Persistence healthchecks for environments like K8s, AWS, Azure, Pivotal Cloud Foundry, and more.</Description>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Akka.HealthCheck.Persistence/AkkaPersistenceLivenessProbe.cs
+++ b/src/Akka.HealthCheck.Persistence/AkkaPersistenceLivenessProbe.cs
@@ -315,7 +315,7 @@ namespace Akka.HealthCheck.Persistence
                 && _deletedJournal is { } 
                 && _deletedSnapshotStore is { })
             {
-                _probe.Tell(CreateStatus(_firstAttempt ? "Warming up probe. Recovery status is still undefined" : null));
+                _probe.Tell(CreateStatus());
                 Context.Stop(Self);
             }
         }

--- a/src/Akka.HealthCheck.Persistence/Properties/FriendsOf.cs
+++ b/src/Akka.HealthCheck.Persistence/Properties/FriendsOf.cs
@@ -1,0 +1,9 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="FriendsOf.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2022 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Akka.HealthCheck.Persistence.Tests")]

--- a/src/Akka.HealthCheck/Liveness/LivenessStatus.cs
+++ b/src/Akka.HealthCheck/Liveness/LivenessStatus.cs
@@ -9,7 +9,7 @@ namespace Akka.HealthCheck.Liveness
     /// <summary>
     ///     Used to signal changes in liveness status to the downstream consumers.
     /// </summary>
-    public sealed class LivenessStatus
+    public class LivenessStatus
     {
         public LivenessStatus(bool isLive, string statusMessage = null)
         {
@@ -21,12 +21,12 @@ namespace Akka.HealthCheck.Liveness
         ///     If <c>true</c>, the current node is live. If <c>false</c>, the current node's
         ///     health is compromised and will likely need to be restarted.
         /// </summary>
-        public bool IsLive { get; }
+        public virtual bool IsLive { get; }
 
         /// <summary>
         ///     An optional status message that will be written out to the
         ///     target (if it supports text) as part of the liveness check.
         /// </summary>
-        public string StatusMessage { get; }
+        public virtual string StatusMessage { get; }
     }
 }


### PR DESCRIPTION
Fixes #49

1. Make sure that the persistence probe hits all the bases:
   - If recovery failed, no need to wait for anything else, just return a status.
   - If snapshot save failed, wait for journal persist to complete/fail and return a status
   - If this is the first time the probe ran, just wait for snapshot save and journal persist to  complete and report a status, there are no message/snapshot deletion.
   - Else wait until the delete message and delete snapshot is complete/fail and report a status
2. Improve the status message for a better reporting experience