### PR TITLE
Improve Akka.HealthCheck.Hosting API and add a sample project

### DIFF
--- a/Akka.HealthCheck.sln
+++ b/Akka.HealthCheck.sln
@@ -36,6 +36,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.HealthCheck.Hosting.We
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.HealthCheck.Hosting.Web.Custom.Example", "src\Akka.HealthCheck.Hosting.Web.Custom.Example\Akka.HealthCheck.Hosting.Web.Custom.Example.csproj", "{1E2AD614-CF7D-4944-BB71-B9B829088157}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.HealthCheck.Hosting.Example", "src\Akka.HealthCheck.Hosting.Example\Akka.HealthCheck.Hosting.Example.csproj", "{9B43DDDA-EAE5-4332-8ACC-00328653B99F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{39EBFADC-25C3-48F7-9332-0DDE8D41FFAA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Hosting", "Hosting", "{3617A966-2DD1-49FB-958F-9C09B88E8603}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.HealthCheck.Hosting.Example.Client", "src\Akka.HealthCheck.Hosting.Example.Client\Akka.HealthCheck.Hosting.Example.Client.csproj", "{8C123D9E-0AD1-4480-9EBE-9DC5D17D1575}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -86,11 +94,27 @@ Global
 		{1E2AD614-CF7D-4944-BB71-B9B829088157}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1E2AD614-CF7D-4944-BB71-B9B829088157}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1E2AD614-CF7D-4944-BB71-B9B829088157}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B43DDDA-EAE5-4332-8ACC-00328653B99F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B43DDDA-EAE5-4332-8ACC-00328653B99F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B43DDDA-EAE5-4332-8ACC-00328653B99F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B43DDDA-EAE5-4332-8ACC-00328653B99F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8C123D9E-0AD1-4480-9EBE-9DC5D17D1575}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C123D9E-0AD1-4480-9EBE-9DC5D17D1575}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C123D9E-0AD1-4480-9EBE-9DC5D17D1575}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C123D9E-0AD1-4480-9EBE-9DC5D17D1575}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B99E6BB8-642A-4A68-86DF-69567CBA700A}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{6213BECB-4145-41BF-BAD0-C5D16412BBD5} = {39EBFADC-25C3-48F7-9332-0DDE8D41FFAA}
+		{1E2AD614-CF7D-4944-BB71-B9B829088157} = {39EBFADC-25C3-48F7-9332-0DDE8D41FFAA}
+		{437E9BF1-75AE-4D1E-A6AF-37F799FAF8A3} = {39EBFADC-25C3-48F7-9332-0DDE8D41FFAA}
+		{3617A966-2DD1-49FB-958F-9C09B88E8603} = {39EBFADC-25C3-48F7-9332-0DDE8D41FFAA}
+		{9B43DDDA-EAE5-4332-8ACC-00328653B99F} = {3617A966-2DD1-49FB-958F-9C09B88E8603}
+		{8C123D9E-0AD1-4480-9EBE-9DC5D17D1575} = {3617A966-2DD1-49FB-958F-9C09B88E8603}
 	EndGlobalSection
 EndGlobal

--- a/src/Akka.HealthCheck.Hosting.Example.Client/Akka.HealthCheck.Hosting.Example.Client.csproj
+++ b/src/Akka.HealthCheck.Hosting.Example.Client/Akka.HealthCheck.Hosting.Example.Client.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+    </ItemGroup>
+
+</Project>

--- a/src/Akka.HealthCheck.Hosting.Example.Client/Program.cs
+++ b/src/Akka.HealthCheck.Hosting.Example.Client/Program.cs
@@ -1,0 +1,23 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="Program.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2023 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.HealthCheck.Hosting.Example.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using var host = new HostBuilder()
+    .ConfigureServices((hostContext, services) =>
+    {
+        services
+            .AddLogging()
+            .AddHostedService<ILivenessProbe>(_ => 
+                new SocketHealthHostedService("liveness", 15000))
+            .AddHostedService<IReadinessProbe>(_ => 
+                new SocketHealthHostedService("readiness", 15001));
+    })
+    .Build();
+
+await host.RunAsync();

--- a/src/Akka.HealthCheck.Hosting.Example.Client/SocketHealthHostedService.cs
+++ b/src/Akka.HealthCheck.Hosting.Example.Client/SocketHealthHostedService.cs
@@ -1,0 +1,92 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="SocketLivenessHostedService.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2023 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Akka.HealthCheck.Hosting.Example.Client;
+
+public interface ILivenessProbe: IHostedService
+{ }
+
+public interface IReadinessProbe: IHostedService
+{ }
+
+public class SocketHealthHostedService: ILivenessProbe, IReadinessProbe
+{
+    private readonly CancellationTokenSource _shutdownCts = new ();
+    private Task? _runTask;
+    private readonly string _name;
+    private readonly int _port;
+
+    public SocketHealthHostedService(string name, int port)
+    {
+        _name = name;
+        _port = port;
+    }
+    
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _runTask = StartService();
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _shutdownCts.Cancel();
+        if(_runTask is { })
+            await _runTask;
+        _shutdownCts.Dispose();
+    }
+
+    private async Task StartService()
+    {
+        var buffer = new byte[256];
+        var endpoint = new IPEndPoint(IPAddress.Loopback, _port);
+        var clientSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        while (!_shutdownCts.IsCancellationRequested)
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(_shutdownCts.Token);
+            timeoutCts.CancelAfter(TimeSpan.FromMilliseconds(250));
+            try
+            {
+                await clientSocket.ConnectAsync(endpoint, timeoutCts.Token);
+            }
+            catch (Exception)
+            {
+                Console.WriteLine($"{_name}: Not Healthy");
+                continue;
+            }
+
+            if (clientSocket.Connected)
+            {
+                var received = clientSocket.Receive(buffer);
+                var message = Encoding.UTF8.GetString(buffer, 0, received);
+                if(message == "akka.net")
+                    Console.WriteLine($"{_name}: Healthy");
+                else
+                    Console.WriteLine($"{_name}: Not Healthy");
+                await clientSocket.DisconnectAsync(true, timeoutCts.Token);
+            }
+            else
+            {
+                Console.WriteLine($"{_name}: Not Healthy");
+            }
+
+            try
+            {
+                await Task.Delay(2000, _shutdownCts.Token);
+            }
+            catch
+            {
+                // no op
+            }
+        }
+    }
+}

--- a/src/Akka.HealthCheck.Hosting.Example/Akka.HealthCheck.Hosting.Example.csproj
+++ b/src/Akka.HealthCheck.Hosting.Example/Akka.HealthCheck.Hosting.Example.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFrameworks>$(NetCoreTestVersion);$(NetTestVersion)</TargetFrameworks>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Akka.HealthCheck.Hosting\Akka.HealthCheck.Hosting.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Akka.Cluster.Hosting" Version="1.0.0" />
+      <PackageReference Include="Akka.Persistence.Hosting" Version="1.0.0" />
+    </ItemGroup>
+
+</Project>

--- a/src/Akka.HealthCheck.Hosting.Example/Program.cs
+++ b/src/Akka.HealthCheck.Hosting.Example/Program.cs
@@ -1,0 +1,40 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="Program.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2023 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Cluster.Hosting;
+using Akka.HealthCheck.Hosting;
+using Akka.Hosting;
+using Akka.Persistence.Hosting;
+using Microsoft.Extensions.Hosting;
+
+using var host = new HostBuilder()
+    .ConfigureServices((hostContext, services) =>
+    {
+        services.AddAkka("test-system", (builder, provider) =>
+        {
+            // Add Akka.Cluster support
+            builder.WithClustering();
+            
+            // Add persistence
+            builder
+                .WithInMemoryJournal()
+                .WithInMemorySnapshotStore();
+
+            // Add Akka.HealthCheck
+            builder.WithHealthCheck(options =>
+            {
+                // Here we're adding all of the built-in providers
+                options.AddProviders(HealthCheckType.All);
+                options.Liveness.Transport = HealthCheckTransport.Tcp;
+                options.Liveness.TcpPort = 15000;
+                options.Readiness.Transport = HealthCheckTransport.Tcp;
+                options.Readiness.TcpPort = 15001;
+            });
+        });
+    })
+    .Build();
+
+await host.RunAsync();

--- a/src/Akka.HealthCheck.Hosting.Web/AkkaWebHostingExtensions.cs
+++ b/src/Akka.HealthCheck.Hosting.Web/AkkaWebHostingExtensions.cs
@@ -19,20 +19,6 @@ using Microsoft.Extensions.Options;
 
 namespace Akka.HealthCheck.Hosting.Web
 {
-    [Flags]
-    public enum HealthCheckType
-    {
-        DefaultLiveness = 1,
-        DefaultReadiness = 2,
-        Default = DefaultLiveness | DefaultReadiness,
-        ClusterLiveness = 4,
-        ClusterReadiness = 8,
-        Cluster = ClusterLiveness | ClusterReadiness,
-        PersistenceLiveness = 16,
-        Persistence = PersistenceLiveness,
-        All = Default | Cluster | Persistence
-    }
-    
     public static class AkkaWebHostingExtensions
     {
         #region IServiceCollection extension methods

--- a/src/Akka.HealthCheck.Hosting/AkkaHealthCheckOptions.cs
+++ b/src/Akka.HealthCheck.Hosting/AkkaHealthCheckOptions.cs
@@ -32,8 +32,8 @@ namespace Akka.HealthCheck.Hosting
 
         public AkkaHealthCheckOptions()
         {
-            Liveness.AddProvider<DefaultLivenessProvider>("default");
-            Readiness.AddProvider<DefaultReadinessProvider>("default");
+            AddDefaultReadinessProvider();
+            AddDefaultLivenessProvider();
         }
         
         public AkkaHealthCheckOptions AddProviders(HealthCheckType healthChecks)

--- a/src/Akka.HealthCheck.Hosting/AkkaHealthCheckOptions.cs
+++ b/src/Akka.HealthCheck.Hosting/AkkaHealthCheckOptions.cs
@@ -5,11 +5,11 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text;
 using Akka.Configuration;
 using Akka.HealthCheck.Cluster;
+using Akka.HealthCheck.Liveness;
 using Akka.HealthCheck.Persistence;
 using Akka.HealthCheck.Readiness;
 using Akka.Hosting;
@@ -25,17 +25,74 @@ namespace Akka.HealthCheck.Hosting
     
     public sealed class AkkaHealthCheckOptions
     {
-        public ProviderOptions Liveness { get; } = new ProviderOptions();
-        public ProviderOptions Readiness { get; } = new ProviderOptions();
+        public ProviderOptions Liveness { get; } = new ();
+        public ProviderOptions Readiness { get; } = new ();
         public bool? LogConfigOnStart { get; set; }
         public bool? LogInfo { get; set; }
 
+        public AkkaHealthCheckOptions()
+        {
+            Liveness.AddProvider<DefaultLivenessProvider>("default");
+            Readiness.AddProvider<DefaultReadinessProvider>("default");
+        }
+        
+        public AkkaHealthCheckOptions AddProviders(HealthCheckType healthChecks)
+        {
+            if ((healthChecks & HealthCheckType.DefaultReadiness) != 0)
+                AddDefaultReadinessProvider();
+
+            if ((healthChecks & HealthCheckType.ClusterReadiness) != 0)
+                AddClusterReadinessProvider();
+
+            if ((healthChecks & HealthCheckType.DefaultLiveness) != 0)
+                AddDefaultLivenessProvider();
+
+            if ((healthChecks & HealthCheckType.ClusterLiveness) != 0)
+                AddClusterLivenessProvider();
+
+            if ((healthChecks & HealthCheckType.PersistenceLiveness) != 0)
+                AddPersistenceLivenessProvider();
+            
+            return this;
+        }
+        
+        public AkkaHealthCheckOptions ClearReadinessProviders()
+        {
+            Readiness.ClearProviders();
+            return this;
+        }
+        
+        public AkkaHealthCheckOptions ClearLivenessProviders()
+        {
+            Liveness.ClearProviders();
+            return this;
+        }
+        
+        public AkkaHealthCheckOptions ClearAllProviders()
+        {
+            Readiness.ClearProviders();
+            Liveness.ClearProviders();
+            return this;
+        }
+
+        public AkkaHealthCheckOptions AddDefaultReadinessProvider()
+        {
+            Readiness.AddProvider<DefaultReadinessProvider>("default");
+            return this;
+        }
+        
         public AkkaHealthCheckOptions AddClusterReadinessProvider()
         {
             Readiness.AddProvider<ClusterReadinessProbeProvider>("cluster");
             return this;
         }
 
+        public AkkaHealthCheckOptions AddDefaultLivenessProvider()
+        {
+            Liveness.AddProvider<DefaultLivenessProvider>("default");
+            return this;
+        }
+        
         public AkkaHealthCheckOptions AddClusterLivenessProvider()
         {
             Liveness.AddProvider<ClusterLivenessProbeProvider>("cluster");
@@ -104,6 +161,12 @@ namespace Akka.HealthCheck.Hosting
         public string? FilePath { get; set; }
         public int? TcpPort { get; set; }
 
+        public ProviderOptions ClearProviders()
+        {
+            Providers = ImmutableDictionary<string, Type>.Empty;
+            return this;
+        }
+        
         public ProviderOptions AddProvider<T>(string key) where T : IProbeProvider
         {
             Providers = Providers.SetItem(key, typeof(T));

--- a/src/Akka.HealthCheck.Hosting/HealthCheckType.cs
+++ b/src/Akka.HealthCheck.Hosting/HealthCheckType.cs
@@ -1,0 +1,23 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="HealthCheckType.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2023 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+
+namespace Akka.HealthCheck.Hosting;
+
+[Flags]
+public enum HealthCheckType
+{
+    DefaultLiveness = 1,
+    DefaultReadiness = 2,
+    Default = DefaultLiveness | DefaultReadiness,
+    ClusterLiveness = 4,
+    ClusterReadiness = 8,
+    Cluster = ClusterLiveness | ClusterReadiness,
+    PersistenceLiveness = 16,
+    Persistence = PersistenceLiveness,
+    All = Default | Cluster | Persistence
+}

--- a/src/Akka.HealthCheck.Tests/Liveness/LivenessTransportActorSpecs.cs
+++ b/src/Akka.HealthCheck.Tests/Liveness/LivenessTransportActorSpecs.cs
@@ -191,10 +191,11 @@ namespace Akka.HealthCheck.Tests.Liveness
                 && testTransport.SystemCalls[12] == TestStatusTransport.TransportCall.Stop);
             
             // transport actor should stop when all probe died
-            Watch(fakeLiveness2);
+            var deathProbe = CreateTestProbe();
+            deathProbe.Watch(fakeLiveness2);
             Watch(transportActor);
             fakeLiveness2.Tell(PoisonPill.Instance);
-            ExpectTerminated(fakeLiveness2);
+            deathProbe.ExpectTerminated(fakeLiveness2);
             ExpectTerminated(transportActor);
             
             // Last Stop call from PostStop

--- a/src/Akka.HealthCheck.Tests/Readiness/ReadinessTransportActorSpecs.cs
+++ b/src/Akka.HealthCheck.Tests/Readiness/ReadinessTransportActorSpecs.cs
@@ -192,10 +192,11 @@ namespace Akka.HealthCheck.Tests.Readiness
                 && testTransport.SystemCalls[12] == TestStatusTransport.TransportCall.Stop);
             
             // transport actor should stop when all probe died
-            Watch(fakeReadiness2);
+            var deathProbe = CreateTestProbe();
+            deathProbe.Watch(fakeReadiness2);
             Watch(transportActor);
             fakeReadiness2.Tell(PoisonPill.Instance);
-            ExpectTerminated(fakeReadiness2);
+            deathProbe.ExpectTerminated(fakeReadiness2);
             ExpectTerminated(transportActor);
             
             // Last Stop call from PostStop

--- a/src/Akka.HealthCheck/Transports/StopTransport.cs
+++ b/src/Akka.HealthCheck/Transports/StopTransport.cs
@@ -1,0 +1,19 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="StopTransport.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2023 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Akka.HealthCheck.Transports;
+
+/// <summary>
+/// Used to signal the transport actor to stop itself, used to gracefully stop the actor.
+/// </summary>
+internal sealed class StopTransport
+{
+    public static readonly StopTransport Instance = new();
+    
+    private StopTransport()
+    {
+    }
+}


### PR DESCRIPTION
### Changes to Akka.HealthCheck.Hosting
- Add convenience method to add multiple probes at once, just like the Web version
- Add methods to clear the provider registry, just like how we did it in the logging API
- Default providers are added by default
- Add sample projects that uses the TCP transport akin to Kubernetes readiness/liveness check