### PR TITLE
Fix missing NuGet package symbol

### DIFF
--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -37,7 +37,7 @@ steps:
   displayName: 'FAKE Build'
   inputs:
     filename: build.cmd
-    arguments: 'All SignClientUser=$(signingUsername) SignClientSecret=$(signingPassword) nugetpublishurl=https://www.nuget.org/api/v2/package nugetkey=$(Akka.NET Tools NuGet)'
+    arguments: 'All SignClientUser=$(signingUsername) SignClientSecret=$(signingPassword) nugetpublishurl=https://api.nuget.org/v3/index.json nugetkey=$(Akka.NET Tools NuGet)'
 
 - task: GitHubRelease@0
   displayName: 'GitHub release (create)'

--- a/build.fsx
+++ b/build.fsx
@@ -248,6 +248,7 @@ Target "CreateNuget" (fun _ ->
                    -- "src/**/*Tests.csproj" // Don't publish unit tests
                    -- "src/**/*Tests*.csproj"
                    -- "src/**/*.Example.csproj" // Don't publish example projects
+                   -- "src/**/*.Example.*.csproj" // Don't publish example projects
 
     let runSingleProject project =
         DotNetCli.Pack
@@ -255,7 +256,7 @@ Target "CreateNuget" (fun _ ->
                 { p with
                     Project = project
                     Configuration = configuration
-                    AdditionalArgs = ["--include-symbols --no-build"]
+                    AdditionalArgs = ["--no-build -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg"]
                     VersionSuffix = versionSuffix
                     OutputPath = "\"" + outputNuGet + "\"" })
 
@@ -263,30 +264,32 @@ Target "CreateNuget" (fun _ ->
 )
 
 Target "PublishNuget" (fun _ ->
-    let projects = !! "./bin/nuget/*.nupkg" -- "./bin/nuget/*.symbols.nupkg"
-    let apiKey = getBuildParamOrDefault "nugetkey" ""
-    let source = getBuildParamOrDefault "nugetpublishurl" ""
-    let symbolSource = getBuildParamOrDefault "symbolspublishurl" ""
-    let shouldPublishSymbolsPackages = not (symbolSource = "")
-
-    if (not (source = "") && not (apiKey = "") && shouldPublishSymbolsPackages) then
-        let runSingleProject project =
-            DotNetCli.RunCommand
-                (fun p -> 
-                    { p with 
-                        TimeOut = TimeSpan.FromMinutes 10. })
-                (sprintf "nuget push %s --api-key %s --source %s --symbol-source %s" project apiKey source symbolSource)
-
-        projects |> Seq.iter (runSingleProject)
-    else if (not (source = "") && not (apiKey = "") && not shouldPublishSymbolsPackages) then
-        let runSingleProject project =
-            DotNetCli.RunCommand
-                (fun p -> 
-                    { p with 
-                        TimeOut = TimeSpan.FromMinutes 10. })
-                (sprintf "nuget push %s --api-key %s --source %s" project apiKey source)
-
-        projects |> Seq.iter (runSingleProject)
+    let shouldPushNugetPackages = hasBuildParam "nugetkey"
+    if not shouldPushNugetPackages then ()
+    else
+        let apiKey = getBuildParam "nugetkey"
+        let sourceUrl = getBuildParamOrDefault "nugetpublishurl" "https://api.nuget.org/v3/index.json"
+        
+        let rec publishPackage retryLeft packageFile =
+            tracefn "Pushing %s Attempts left: %d" (FullName packageFile) retryLeft
+            let tracing = ProcessHelper.enableProcessTracing
+            try
+                try
+                    ProcessHelper.enableProcessTracing <- false
+                    DotNetCli.RunCommand
+                        (fun p ->
+                            { p with
+                                TimeOut = TimeSpan.FromMinutes 10. })
+                        (sprintf "nuget push %s --api-key %s --source %s --no-service-endpoint" packageFile apiKey sourceUrl)
+                with exn ->
+                    if (retryLeft > 0) then (publishPackage (retryLeft-1) packageFile)
+            finally
+                ProcessHelper.enableProcessTracing <- tracing
+                
+        printfn "Pushing nuget packages"
+        let normalPackages = !! (outputNuGet @@ "*.nupkg") |> Seq.sortBy(fun x -> x.ToLower())
+        for package in normalPackages do
+            publishPackage 3 package
 )
 
 //--------------------------------------------------------------------------------


### PR DESCRIPTION
## Changes

Fix Fake and AzDo script

* Add nuget package upload retry mechanism
* Make sure that nuget API key are not leaked via build output
* Remove symbolpublishurl parameter, this should be inferred from the service discovery URL, not baked in.
* Add default publish source URI, defaults to http://api.nuget.org/v3/index.json
* Change AzDo nugetpublishurl parameter to point to the service discovery URL instead of the package upload URL