### PR TITLE
Fix persistence liveness check deadlock

### DIFF
--- a/src/Akka.HealthCheck.Persistence.Tests/AkkaPersistenceLivenessProbeNotAvailableDueToSnapshotStoreSpecs.cs
+++ b/src/Akka.HealthCheck.Persistence.Tests/AkkaPersistenceLivenessProbeNotAvailableDueToSnapshotStoreSpecs.cs
@@ -10,6 +10,7 @@ using Akka.Util.Internal;
 using FluentAssertions;
 using System;
 using System.Threading.Tasks;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 using static Akka.HealthCheck.Persistence.AkkaPersistenceLivenessProbe;
@@ -27,7 +28,7 @@ namespace Akka.HealthCheck.Persistence.Tests
         public void AkkaPersistenceLivenessProbeProvidert_Should_Report_Akka_Persistance_Is_Unavailable_With_Bad_Snapshot_Store_Setup()
         {
 
-            var ProbActor = Sys.ActorOf(Props.Create(() => new AkkaPersistenceLivenessProbe(true, TimeSpan.FromMilliseconds(250))));
+            var ProbActor = Sys.ActorOf(Props.Create(() => new AkkaPersistenceLivenessProbe(true, 250.Milliseconds(), 3.Seconds())));
             ProbActor.Tell(new SubscribeToLiveness(TestActor));
             ExpectMsg<LivenessStatus>().IsLive.Should().BeFalse("System should not be live");
             ExpectMsg<LivenessStatus>(TimeSpan.FromMinutes(1)).IsLive.Should().BeFalse("System should not be live");

--- a/src/Akka.HealthCheck.Persistence.Tests/AkkaPersistenceLivenessProbeNotAvailableduetoJournalSpecs.cs
+++ b/src/Akka.HealthCheck.Persistence.Tests/AkkaPersistenceLivenessProbeNotAvailableduetoJournalSpecs.cs
@@ -8,6 +8,7 @@ using Akka.HealthCheck.Liveness;
 using Akka.Util.Internal;
 using FluentAssertions;
 using System;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 using static Akka.HealthCheck.Persistence.AkkaPersistenceLivenessProbe;
@@ -26,7 +27,7 @@ namespace Akka.HealthCheck.Persistence.Tests
         public void AkkaPersistenceLivenessProbeProvidert_Should_Report_Akka_Persistance_Is_Unavailable_With_Bad_Journal_Setup()
         {
             
-            var ProbActor = Sys.ActorOf(Props.Create(() => new AkkaPersistenceLivenessProbe(true, TimeSpan.FromMilliseconds(250))));
+            var ProbActor = Sys.ActorOf(Props.Create(() => new AkkaPersistenceLivenessProbe(true, 250.Milliseconds(), 3.Seconds())));
             ProbActor.Tell(new SubscribeToLiveness(TestActor));
             ExpectMsg<LivenessStatus>().IsLive.Should().BeFalse("System should not be live");
             ExpectMsg<LivenessStatus>(TimeSpan.FromMinutes(1)).IsLive.Should().BeFalse("System should not be live");

--- a/src/Akka.HealthCheck.Persistence.Tests/AkkaPersistenceLivenessProbeSubscriptionTest.cs
+++ b/src/Akka.HealthCheck.Persistence.Tests/AkkaPersistenceLivenessProbeSubscriptionTest.cs
@@ -9,6 +9,7 @@ using Akka.Util;
 using Akka.Util.Internal;
 using FluentAssertions;
 using System;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -27,7 +28,7 @@ namespace Akka.HealthCheck.Persistence.Tests
         [Fact(DisplayName = "AkkaPersistenceLivenessProbe should correctly handle subscription requests")]
         public void AkkaPersistenceLivenessProbe_Should_Handle_Subscriptions_In_Any_State()
         {
-            var ProbActor = Sys.ActorOf(Props.Create(() => new AkkaPersistenceLivenessProbe(true, TimeSpan.FromMilliseconds(250))));
+            var ProbActor = Sys.ActorOf(Props.Create(() => new AkkaPersistenceLivenessProbe(true, 250.Milliseconds(), 3.Seconds())));
             ProbActor.Tell(new SubscribeToLiveness(TestActor));
             ExpectMsg<LivenessStatus>().IsLive.Should().BeFalse();
             AwaitAssert(() => ExpectMsg<LivenessStatus>().IsLive.Should().BeTrue(),TimeSpan.FromSeconds(10));

--- a/src/Akka.HealthCheck.Persistence.Tests/JournalInterceptors.cs
+++ b/src/Akka.HealthCheck.Persistence.Tests/JournalInterceptors.cs
@@ -1,0 +1,58 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="JournalInterceptors.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Persistence;
+using Akka.Persistence.TestKit;
+
+namespace Akka.HealthCheck.Persistence.Tests;
+
+public static class JournalInterceptors
+{
+    internal class Noop : IJournalInterceptor
+    {
+        public static readonly Noop Instance = new ();
+
+        private Noop()
+        {}
+        
+        public Task InterceptAsync(IPersistentRepresentation message) => Task.FromResult(true);
+    }
+
+    public class CancelableDelay: IJournalInterceptor
+    {
+        public CancelableDelay(TimeSpan delay, IJournalInterceptor next, CancellationToken cancellationToken)
+        {
+            _delay = delay;
+            _next = next;
+            _cancellationToken = cancellationToken;
+        }
+
+        private readonly TimeSpan _delay;
+        private readonly IJournalInterceptor _next;
+        private readonly CancellationToken _cancellationToken;
+
+        public async Task InterceptAsync(IPersistentRepresentation message)
+        {
+            try
+            {
+                await Task.Delay(_delay, _cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // no-op
+            }
+            catch (TimeoutException)
+            {
+                // no-op
+            }
+            await _next.InterceptAsync(message);
+        }
+    }    
+
+}

--- a/src/Akka.HealthCheck.Persistence.Tests/LivenessProbeTimeoutSpec.cs
+++ b/src/Akka.HealthCheck.Persistence.Tests/LivenessProbeTimeoutSpec.cs
@@ -1,0 +1,92 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="LivenessProbeTimeoutSpec.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.HealthCheck.Liveness;
+using Akka.Persistence.TestKit;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.HealthCheck.Persistence.Tests;
+
+public class LivenessProbeTimeoutSpec: PersistenceTestKit
+{
+    public LivenessProbeTimeoutSpec(ITestOutputHelper output) : base(nameof(LivenessProbeTimeoutSpec), output)
+    {
+    }
+    
+    [Fact(DisplayName = "AkkaPersistenceLivenessProbe should time out if SaveSnapshot does not respond")]
+    public async Task SaveSnapshotTimeoutTest()
+    {
+        using var cts = new CancellationTokenSource();
+        var delay = new SnapshotInterceptors.CancelableDelay(30.Minutes(), SnapshotInterceptors.Noop.Instance, cts.Token);
+
+        await WithSnapshotSave(
+            save => save.SetInterceptorAsync(delay),
+            () => TestTimeout(cts));
+    }
+
+    [Fact(DisplayName = "AkkaPersistenceLivenessProbe should time out if snapshot recovery does not respond")]
+    public async Task SnapshotLoadTimeoutTest()
+    {
+        using var cts = new CancellationTokenSource();
+        var delay = new SnapshotInterceptors.CancelableDelay(30.Minutes(), SnapshotInterceptors.Noop.Instance, cts.Token);
+
+        await WithSnapshotLoad(
+            save => save.SetInterceptorAsync(delay),
+            () => TestTimeout(cts));
+    }
+    
+    [Fact(DisplayName = "AkkaPersistenceLivenessProbe should time out if journal Persist does not respond")]
+    public async Task JournalPersistTimeoutTest()
+    {
+        using var cts = new CancellationTokenSource();
+        var delay = new JournalInterceptors.CancelableDelay(30.Minutes(), JournalInterceptors.Noop.Instance, cts.Token);
+
+        await WithJournalWrite(
+            save => save.SetInterceptorAsync(delay),
+            () => TestTimeout(cts));
+    }
+
+    [Fact(DisplayName = "AkkaPersistenceLivenessProbe should time out if journal recovery does not respond")]
+    public async Task JournalRecoveryTimeoutTest()
+    {
+        using var cts = new CancellationTokenSource();
+        var delay = new JournalInterceptors.CancelableDelay(30.Minutes(), JournalInterceptors.Noop.Instance, cts.Token);
+
+        await WithJournalRecovery(
+            save => save.SetInterceptorAsync(delay),
+            () => TestTimeout(cts));
+    }
+    
+    private async Task TestTimeout(CancellationTokenSource cts)
+    {
+        var probeActor = Sys.ActorOf(Props.Create(() => new AkkaPersistenceLivenessProbe(true, 250.Milliseconds(), 500.Milliseconds())));
+        probeActor.Tell(new SubscribeToLiveness(TestActor));
+        var status = ExpectMsg<LivenessStatus>();
+        status.IsLive.Should().BeFalse();
+        status.StatusMessage.Should().StartWith("Warming up probe.");
+
+        var timeoutStatusObj = await FishForMessageAsync(
+            msg => msg is LivenessStatus stat && !stat.StatusMessage.StartsWith("Warming up probe."), 
+            6.Seconds());
+
+        var timeoutStatus = (LivenessStatus)timeoutStatusObj;
+        timeoutStatus.IsLive.Should().BeFalse();
+        timeoutStatus.StatusMessage.Should().StartWith("Timeout while checking persistence liveness.");
+        
+        cts.Cancel();
+        
+        await AwaitAssertAsync(
+            () => ExpectMsg<LivenessStatus>().IsLive.Should().BeTrue(),
+            TimeSpan.FromSeconds(10));
+    }
+}

--- a/src/Akka.HealthCheck.Persistence.Tests/RegressionProbeFailureSpec.cs
+++ b/src/Akka.HealthCheck.Persistence.Tests/RegressionProbeFailureSpec.cs
@@ -31,7 +31,7 @@ public class RegressionProbeFailureSpec: PersistenceTestKit
         {
             Sys.EventStream.Subscribe(TestActor, typeof(LogEvent));
             var probe = Sys.ActorOf(Props.Create(() =>
-                new AkkaPersistenceLivenessProbe(true, TimeSpan.FromMilliseconds(400))));
+                new AkkaPersistenceLivenessProbe(true, 400.Milliseconds(), 3.Seconds())));
             await FishForMessageAsync<LogEvent>(e => e.Message.ToString() is "Recreating persistence probe.");
 
             var stopwatch = Stopwatch.StartNew();

--- a/src/Akka.HealthCheck.Persistence.Tests/SnapshotInterceptors.cs
+++ b/src/Akka.HealthCheck.Persistence.Tests/SnapshotInterceptors.cs
@@ -1,0 +1,58 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="FailingTestSnapshotStore.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Persistence;
+using Akka.Persistence.TestKit;
+
+namespace Akka.HealthCheck.Persistence.Tests;
+
+public static class SnapshotInterceptors
+{
+    public class Noop : ISnapshotStoreInterceptor
+    {
+        public static readonly Noop Instance = new ();
+
+        private Noop()
+        {
+        }
+    
+        public Task InterceptAsync(string persistenceId, SnapshotSelectionCriteria criteria) => Task.FromResult(true);
+    }
+
+    public class CancelableDelay: ISnapshotStoreInterceptor
+    {
+        public CancelableDelay(TimeSpan delay, ISnapshotStoreInterceptor next, CancellationToken cancellationToken)
+        {
+            _delay = delay;
+            _next = next;
+            _cancellationToken = cancellationToken;
+        }
+
+        private readonly TimeSpan _delay;
+        private readonly ISnapshotStoreInterceptor _next;
+        private readonly CancellationToken _cancellationToken;
+
+        public async Task InterceptAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        {
+            try
+            {
+                await Task.Delay(_delay, _cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // no-op
+            }
+            catch (TimeoutException)
+            {
+                // no-op
+            }
+            await _next.InterceptAsync(persistenceId, criteria);
+        }
+    }    
+}

--- a/src/Akka.HealthCheck.Persistence/AkkaPersistenceLivenessProbeProvider.cs
+++ b/src/Akka.HealthCheck.Persistence/AkkaPersistenceLivenessProbeProvider.cs
@@ -15,15 +15,16 @@ namespace Akka.HealthCheck.Persistence
     public sealed class AkkaPersistenceLivenessProbeProvider : ProbeProviderBase
     {
         private readonly TimeSpan _interval;
+        private readonly TimeSpan _timeout;
         
         public AkkaPersistenceLivenessProbeProvider(ActorSystem system) : base(system)
         {
-            _interval = system.Settings.Config.GetTimeSpan(
-                path: "akka.healthcheck.liveness.persistence.probe-interval",
-                @default: TimeSpan.FromSeconds(10));
+            var config = system.Settings.Config.GetConfig("akka.healthcheck.liveness.persistence");
+            _interval = config.GetTimeSpan("probe-interval", TimeSpan.FromSeconds(10));
+            _timeout = config.GetTimeSpan("timeout", TimeSpan.FromSeconds(3));
         }
 
         public override Props ProbeProps => 
-            AkkaPersistenceLivenessProbe.PersistentHealthCheckProps(Settings.LogInfoEvents, _interval);
+            AkkaPersistenceLivenessProbe.PersistentHealthCheckProps(Settings.LogInfoEvents, _interval, _timeout);
     }
 }

--- a/src/Akka.HealthCheck/Configuration/akka.healthcheck.conf
+++ b/src/Akka.HealthCheck/Configuration/akka.healthcheck.conf
@@ -30,8 +30,13 @@ akka.healthcheck{
 	        #persistence = "Akka.HealthCheck.Cluster.AkkaPersistenceLivenessProbeProvider, Akka.HealthCheck.Persistence"
 	    }
 	    
-	    # Defines the interval for each persistence liveness health check probe refresh
-	    persistence.probe-interval = 10s
+	    persistence {
+	        # Defines the interval for each persistence liveness health check probe refresh
+	        probe-interval = 10s
+	        
+	        # Defines the timeout for each liveness check operation
+	        timeout = 3s
+	    }
 
 		# Defines the signaling mechanism used to communicate with K8s, AWS, Azure,
 		# or whatever the hosting environment is for the Akka.NET application. The


### PR DESCRIPTION
Fix potential persistence liveness check deadlock if the suicide actor never completes due to peristence actor / storage problems.