### PR TITLE
Make persistence probe return degraded during warmup

### DIFF
--- a/src/Akka.HealthCheck.Cluster/ClusterLivenessProbe.cs
+++ b/src/Akka.HealthCheck.Cluster/ClusterLivenessProbe.cs
@@ -18,7 +18,7 @@ namespace Akka.HealthCheck.Cluster
     public sealed class ClusterLivenessProbe : ReceiveActor
     {
         public static readonly LivenessStatus DefaultClusterLivenessStatus =
-            new LivenessStatus(true, "not yet joined cluster");
+            LivenessStatus.Degraded("not yet joined cluster");
 
         private readonly Akka.Cluster.Cluster _cluster = Akka.Cluster.Cluster.Get(Context.System);
         private readonly ILoggingAdapter _log = Context.GetLogger();
@@ -64,9 +64,9 @@ namespace Akka.HealthCheck.Cluster
         {
             var self = Self;
 
-            _cluster.RegisterOnMemberUp(() => { self.Tell(new LivenessStatus(true)); });
+            _cluster.RegisterOnMemberUp(() => { self.Tell(LivenessStatus.Healthy()); });
 
-            _cluster.RegisterOnMemberRemoved(() => { self.Tell(new LivenessStatus(false)); });
+            _cluster.RegisterOnMemberRemoved(() => { self.Tell(LivenessStatus.Unhealthy()); });
         }
     }
 }

--- a/src/Akka.HealthCheck.Hosting.Web/Probes/AkkaPersistenceLivenessProbe.cs
+++ b/src/Akka.HealthCheck.Hosting.Web/Probes/AkkaPersistenceLivenessProbe.cs
@@ -23,6 +23,7 @@ namespace Akka.HealthCheck.Hosting.Web.Probes
     {
         private const string Healthy = "Akka.NET persistence is alive";
         private const string UnHealthy = "Akka.NET persistence is not alive";
+        private const string Degraded = "Akka.NET persistence liveness is degraded";
         private const string Exception = "Exception occured when processing cluster liveness";
         
         private readonly IActorRef _probe;
@@ -47,23 +48,35 @@ namespace Akka.HealthCheck.Hosting.Web.Probes
                 var status = await _probe.Ask<PersistenceLivenessStatus>(
                     message: GetCurrentLiveness.Instance, 
                     cancellationToken: cancellationToken);
-                return status.IsLive 
-                    ? HealthCheckResult.Healthy(Healthy, new Dictionary<string, object>
-                    {
-                        ["journal-recovered"] = status.JournalRecovered,
-                        ["snapshot-recovered"] = status.SnapshotRecovered,
-                        ["journal-persisted"] = status.JournalPersisted,
-                        ["snapshot-persisted"] = status.SnapshotSaved,
-                        ["message"] = status.StatusMessage
-                    })
-                    : HealthCheckResult.Unhealthy(UnHealthy, status.Failures, new Dictionary<string, object>
-                    {
-                        ["journal-recovered"] = status.JournalRecovered,
-                        ["snapshot-recovered"] = status.SnapshotRecovered,
-                        ["journal-persisted"] = status.JournalPersisted,
-                        ["snapshot-persisted"] = status.SnapshotSaved,
-                        ["message"] = status.StatusMessage
-                    });
+                return status.Status switch
+                {
+                    AkkaHealthStatus.Healthy => HealthCheckResult.Healthy(Healthy, new Dictionary<string, object>
+                        {
+                            ["journal-recovered"] = status.JournalRecovered,
+                            ["snapshot-recovered"] = status.SnapshotRecovered,
+                            ["journal-persisted"] = status.JournalPersisted,
+                            ["snapshot-persisted"] = status.SnapshotSaved,
+                            ["message"] = status.StatusMessage
+                        }),
+                    AkkaHealthStatus.Unhealthy => HealthCheckResult.Unhealthy(UnHealthy, status.Failures,
+                        new Dictionary<string, object>
+                        {
+                            ["journal-recovered"] = status.JournalRecovered,
+                            ["snapshot-recovered"] = status.SnapshotRecovered,
+                            ["journal-persisted"] = status.JournalPersisted,
+                            ["snapshot-persisted"] = status.SnapshotSaved,
+                            ["message"] = status.StatusMessage
+                        }),
+                    _ => HealthCheckResult.Degraded(Degraded, status.Failures,
+                        new Dictionary<string, object>
+                        {
+                            ["journal-recovered"] = status.JournalRecovered,
+                            ["snapshot-recovered"] = status.SnapshotRecovered,
+                            ["journal-persisted"] = status.JournalPersisted,
+                            ["snapshot-persisted"] = status.SnapshotSaved,
+                            ["message"] = status.StatusMessage
+                        })
+                };
             }
             catch (Exception e)
             {

--- a/src/Akka.HealthCheck.Persistence.Tests/ProbeFailureSpec.cs
+++ b/src/Akka.HealthCheck.Persistence.Tests/ProbeFailureSpec.cs
@@ -111,7 +111,7 @@ namespace Akka.HealthCheck.Persistence.Tests
             {
                 var status = PerformProbe();
                 status.IsLive.Should().BeFalse();
-                status.JournalRecovered.Should().BeFalse();
+                status.JournalRecovered.Should().BeNull();
                 status.JournalPersisted.Should().BeFalse();
                 status.SnapshotRecovered.Should().BeTrue();
                 status.SnapshotSaved.Should().BeFalse();
@@ -128,9 +128,9 @@ namespace Akka.HealthCheck.Persistence.Tests
             {
                 var status = PerformProbe();
                 status.IsLive.Should().BeFalse();
-                status.JournalRecovered.Should().BeFalse();
+                status.JournalRecovered.Should().BeNull();
                 status.JournalPersisted.Should().BeFalse();
-                status.SnapshotRecovered.Should().BeFalse();
+                status.SnapshotRecovered.Should().BeNull();
                 status.SnapshotSaved.Should().BeFalse();
                 var e = status.Failures!.Flatten().InnerExceptions[0];
                 e.Should().BeOfType<TestSnapshotStoreFailureException>();

--- a/src/Akka.HealthCheck.Persistence/AkkaPersistenceLivenessProbe.cs
+++ b/src/Akka.HealthCheck.Persistence/AkkaPersistenceLivenessProbe.cs
@@ -18,17 +18,19 @@ namespace Akka.HealthCheck.Persistence
     {
         private readonly string? _message;
         
-        public PersistenceLivenessStatus(string message): this(null, null, false, false, Array.Empty<Exception>(), message)
+        public PersistenceLivenessStatus(AkkaHealthStatus status, string message)
+            : this(status, null, null, false, false, Array.Empty<Exception>(), message)
         {
         }
 
         public PersistenceLivenessStatus(
+            AkkaHealthStatus status,
             bool? journalRecovered,
             bool? snapshotRecovered,
             bool journalPersisted,
             bool snapshotSaved, 
             IReadOnlyCollection<Exception> failures, 
-            string? message = null): base(false)
+            string? message = null): base(status)
         {
             JournalRecovered = journalRecovered;
             SnapshotRecovered = snapshotRecovered;
@@ -38,7 +40,8 @@ namespace Akka.HealthCheck.Persistence
             _message = message;
         }
 
-        public override bool IsLive => JournalRecovered is true
+        public override bool IsLive => base.IsLive && 
+                                       JournalRecovered is true
                                        && SnapshotRecovered is true
                                        && JournalPersisted
                                        && SnapshotSaved
@@ -92,7 +95,7 @@ namespace Akka.HealthCheck.Persistence
         
         private readonly ILoggingAdapter _log = Context.GetLogger();
         private readonly HashSet<IActorRef> _subscribers = new HashSet<IActorRef>();
-        private PersistenceLivenessStatus _currentLivenessStatus = new(message: "Warming up probe. Recovery status is still undefined");
+        private PersistenceLivenessStatus _currentLivenessStatus = new(AkkaHealthStatus.Degraded, "Warming up probe. Recovery status is still undefined");
         private IActorRef? _probe;
         private int _probeCounter;
         private bool _warmup = true;
@@ -183,7 +186,8 @@ namespace Akka.HealthCheck.Persistence
                         _log.Debug("Recreating persistence probe.");
                     
                     Timers.StartSingleTimer(TimeoutTimerKey, CheckTimeout.Instance, _timeout);
-                    _probe = Context.ActorOf(Props.Create(() => new SuicideProbe(Self, _warmup, _id, _logInfo)));
+                    _probe = Context.ActorOf(Props.Create(() => new SuicideProbe(Self, _warmup, _id, _logInfo))
+                        .WithSupervisorStrategy(Actor.SupervisorStrategy.StoppingStrategy));
                     Context.Watch(_probe);
                     _probe.Tell("hit" + _probeCounter);
                     _probeCounter++;
@@ -192,7 +196,7 @@ namespace Akka.HealthCheck.Persistence
                 case CheckTimeout:
                     const string errMsg = "Timeout while checking persistence liveness. Persistence liveness status is undefined.";
                     _log.Warning(errMsg);
-                    _currentLivenessStatus = new PersistenceLivenessStatus(errMsg);
+                    _currentLivenessStatus = new PersistenceLivenessStatus(AkkaHealthStatus.Unhealthy, errMsg);
                     PublishStatusUpdates();
                     
                     if(_probe is not null)
@@ -277,9 +281,15 @@ namespace Akka.HealthCheck.Persistence
             {
                 if(_debugLog)
                     _log.Debug($"{PersistenceId}: Recovery complete");
-                DeleteMessages(long.MaxValue);
-                DeleteSnapshots(new SnapshotSelectionCriteria(long.MaxValue));
+                Become(CleanupMessages);
             });
+            
+            CommandAny(_ => Stash.Stash());
+        }
+
+        private void CleanupMessages()
+        {
+            DeleteMessages(long.MaxValue);
             
             Command<DeleteMessagesSuccess>(_ =>
             {
@@ -287,11 +297,7 @@ namespace Akka.HealthCheck.Persistence
                 if(_debugLog)
                     _log.Debug($"{PersistenceId}: Journal events deleted");
                 
-                if(_deletedSnapshotStore is not null)
-                {
-                    Become(Active);
-                    Stash.UnstashAll();
-                }
+                Become(CleanupSnapshot);
             });
             
             Command<DeleteMessagesFailure>(fail =>
@@ -301,12 +307,15 @@ namespace Akka.HealthCheck.Persistence
                 if(_debugLog)
                     _log.Debug($"{PersistenceId}: Failed to delete journal events");
                 
-                if(_deletedSnapshotStore is not null)
-                {
-                    Become(Active);
-                    Stash.UnstashAll();
-                }
+                Become(CleanupSnapshot);
             });
+            
+            CommandAny(_ => Stash.Stash());
+        }
+
+        private void CleanupSnapshot()
+        {
+            DeleteSnapshots(new SnapshotSelectionCriteria(long.MaxValue));
             
             Command<DeleteSnapshotsSuccess>(_ =>
             {
@@ -314,11 +323,8 @@ namespace Akka.HealthCheck.Persistence
                 if(_debugLog)
                     _log.Debug($"{PersistenceId}: Snapshot deleted");
                 
-                if(_deletedJournal is not null)
-                {
-                    Become(Active);
-                    Stash.UnstashAll();
-                }
+                Become(Active);
+                Stash.UnstashAll();
             });
             
             Command<DeleteSnapshotsFailure>(fail =>
@@ -328,11 +334,8 @@ namespace Akka.HealthCheck.Persistence
                 if(_debugLog)
                     _log.Debug($"{PersistenceId}: Failed to delete snapshot");
                 
-                if(_deletedJournal is not null)
-                {
-                    Become(Active);
-                    Stash.UnstashAll();
-                }
+                Become(Active);
+                Stash.UnstashAll();
             });
             
             CommandAny(_ => Stash.Stash());
@@ -345,40 +348,46 @@ namespace Akka.HealthCheck.Persistence
                 _message = str;
                 if(_debugLog)
                     _log.Debug($"{PersistenceId}: Probe started, saving snapshot");
-                SaveSnapshot(str);
+                Become(SavingSnapshot(str));
             });
-            
-            Command<SaveSnapshotSuccess>(_ =>
-            {
-                _persistedSnapshotStore = true;
-                if(_debugLog)
-                    _log.Debug($"{PersistenceId}: Snapshot saved");
-                Persist(_message, 
-                    _ =>
-                    {
-                        _persistedJournal = true;
-                        if(_debugLog)
-                            _log.Debug($"{PersistenceId}: Journal persisted");
-                        SendRecoveryStatusWhenFinished();
-                    });
-            });
-            
-            Command<SaveSnapshotFailure>(fail =>
-            {
-                _log.Error(fail.Cause,"Failed to save snapshot store");
-                
-                _failures.Add(fail.Cause);
-                _persistedSnapshotStore = false;
-                Persist(_message, 
-                    _ =>
-                    {
-                        _persistedJournal = true;
-                        if(_debugLog)
-                            _log.Debug($"{PersistenceId}: Journal persisted");
-                        SendRecoveryStatusWhenFinished();
-                    });
-            });
+        }
 
+        private Action SavingSnapshot(string msg)
+        {
+            SaveSnapshot(msg);
+            return () =>
+            {
+                Command<SaveSnapshotSuccess>(_ =>
+                {
+                    _persistedSnapshotStore = true;
+                    if(_debugLog)
+                        _log.Debug($"{PersistenceId}: Snapshot saved");
+                    Become(PersistMessage(msg));
+                });
+            
+                Command<SaveSnapshotFailure>(fail =>
+                {
+                    _log.Error(fail.Cause,"Failed to save snapshot store");
+                
+                    _failures.Add(fail.Cause);
+                    _persistedSnapshotStore = false;
+                    Become(PersistMessage(msg));
+                });
+            };
+        }
+
+        private Action PersistMessage(string msg)
+        {
+            Persist(msg, 
+                _ =>
+                {
+                    _persistedJournal = true;
+                    if(_debugLog)
+                        _log.Debug($"{PersistenceId}: Journal persisted");
+                    SendRecoveryStatusWhenFinished();
+                });
+
+            return () => { };
         }
 
         public override string PersistenceId { get; }
@@ -386,7 +395,8 @@ namespace Akka.HealthCheck.Persistence
         private void SendRecoveryStatusWhenFinished()
         {
             // First case, snapshot failed to save or journal write was rejected, there will be no deletion.
-            if( (_persistedSnapshotStore is false && _persistedJournal is { }) || (_persistedJournal is false && _persistedSnapshotStore is { }))
+            if( (_persistedSnapshotStore is false && _persistedJournal is not null) || 
+                (_persistedJournal is false && _persistedSnapshotStore is not null))
             {
                 _probe.Tell(CreateStatus());
                 Context.Stop(Self);
@@ -462,10 +472,16 @@ namespace Akka.HealthCheck.Persistence
             _probe.Tell(CreateStatus(msg));
             Context.Stop(Self);
         }
+        
+        private bool IsHealthy => _recoveredJournal is true && 
+                                  _recoveredSnapshotStore is true && 
+                                  _persistedJournal is true && 
+                                  _persistedSnapshotStore is true; 
 
         private PersistenceLivenessStatus CreateStatus(string? message = null)
             => _firstAttempt
                 ? new PersistenceLivenessStatus(
+                    status: AkkaHealthStatus.Degraded,
                     journalRecovered: _recoveredJournal,
                     snapshotRecovered: _recoveredSnapshotStore,
                     journalPersisted: _persistedJournal ?? false,
@@ -473,8 +489,9 @@ namespace Akka.HealthCheck.Persistence
                     failures: _failures,
                     message: message)
                 : new PersistenceLivenessStatus(
-                    journalRecovered: _recoveredJournal ?? false,
-                    snapshotRecovered: _recoveredSnapshotStore ?? false,
+                    status: IsHealthy ? AkkaHealthStatus.Healthy : AkkaHealthStatus.Unhealthy,
+                    journalRecovered: _recoveredJournal,
+                    snapshotRecovered: _recoveredSnapshotStore,
                     journalPersisted: _persistedJournal ?? false,
                     snapshotSaved: _persistedSnapshotStore ?? false,
                     failures: _failures,

--- a/src/Akka.HealthCheck.Tests/AkkaHealthCheckSpecs.cs
+++ b/src/Akka.HealthCheck.Tests/AkkaHealthCheckSpecs.cs
@@ -22,7 +22,7 @@ namespace Akka.HealthCheck.Tests
             private readonly LivenessStatus _livenessStatus;
             private readonly ReadinessStatus _readinessStatus;
 
-            public CustomProbe() : this(new LivenessStatus(true), new ReadinessStatus(true))
+            public CustomProbe() : this(LivenessStatus.Healthy(), new ReadinessStatus(true))
             {
             }
 

--- a/src/Akka.HealthCheck.Tests/Liveness/LivenessTransportActorSpecs.cs
+++ b/src/Akka.HealthCheck.Tests/Liveness/LivenessTransportActorSpecs.cs
@@ -41,7 +41,7 @@ namespace Akka.HealthCheck.Tests.Liveness
             // we expect the LivenessTransportActor to throw this exception
             EventFilter.Exception<ProbeUpdateException>().ExpectOne(() =>
             {
-                fakeLiveness.Reply(new LivenessStatus(true));
+                fakeLiveness.Reply(LivenessStatus.Healthy());
 
                 AwaitCondition(() => testTransport.SystemCalls.Count == 2
                                      && testTransport.SystemCalls[0] == TestStatusTransport.TransportCall.Go);
@@ -54,7 +54,7 @@ namespace Akka.HealthCheck.Tests.Liveness
             // should throw second exception when we try to change status again
             EventFilter.Exception<ProbeUpdateException>().ExpectOne(() =>
             {
-                fakeLiveness.Reply(new LivenessStatus(false));
+                fakeLiveness.Reply(LivenessStatus.Unhealthy());
 
                 AwaitCondition(() => testTransport.SystemCalls.Count == 4
                                      && testTransport.SystemCalls.Count(x =>
@@ -77,13 +77,13 @@ namespace Akka.HealthCheck.Tests.Liveness
                 Sys.ActorOf(Props.Create(() => new LivenessTransportActor(testTransport, dict, true)));
 
             fakeLiveness.ExpectMsg<SubscribeToLiveness>();
-            fakeLiveness.Reply(new LivenessStatus(true));
+            fakeLiveness.Reply(LivenessStatus.Healthy());
 
             AwaitCondition(() => testTransport.SystemCalls.Count == 2
                                  && testTransport.SystemCalls[0] == TestStatusTransport.TransportCall.Go);
 
             fakeLiveness.ExpectMsg<SubscribeToLiveness>();
-            fakeLiveness.Reply(new LivenessStatus(false));
+            fakeLiveness.Reply(LivenessStatus.Unhealthy());
             AwaitCondition(() => testTransport.SystemCalls.Count == 4
                                  && testTransport.SystemCalls.Count(x => x == TestStatusTransport.TransportCall.Go) == 1
                                  && testTransport.SystemCalls.Count(x => x == TestStatusTransport.TransportCall.Stop) == 3,
@@ -101,12 +101,12 @@ namespace Akka.HealthCheck.Tests.Liveness
                 Sys.ActorOf(Props.Create(() => new LivenessTransportActor(testTransport, dict, true)));
 
             fakeLiveness.ExpectMsg<SubscribeToLiveness>();
-            fakeLiveness.Reply(new LivenessStatus(true));
+            fakeLiveness.Reply(LivenessStatus.Healthy());
 
             AwaitCondition(() => testTransport.SystemCalls.Count == 1
                                  && testTransport.SystemCalls[0] == TestStatusTransport.TransportCall.Go);
 
-            fakeLiveness.Reply(new LivenessStatus(false));
+            fakeLiveness.Reply(LivenessStatus.Unhealthy());
             AwaitCondition(() => testTransport.SystemCalls.Count == 2
                                  && testTransport.SystemCalls[1] == TestStatusTransport.TransportCall.Stop);
         }
@@ -149,13 +149,13 @@ namespace Akka.HealthCheck.Tests.Liveness
             fakeLiveness2.ExpectMsg<SubscribeToLiveness>();
 
             // "second" status should still be false because it has not reported in yet
-            transportActor.Tell(new LivenessStatus(true), fakeLiveness1);
+            transportActor.Tell(LivenessStatus.Healthy(), fakeLiveness1);
             await AwaitConditionAsync(() => 
                 testTransport.SystemCalls.Count == 1 
                 && testTransport.SystemCalls[0] == TestStatusTransport.TransportCall.Stop);
             
             // both probe status is true, Go should be called
-            transportActor.Tell(new LivenessStatus(true), fakeLiveness2);
+            transportActor.Tell(LivenessStatus.Healthy(), fakeLiveness2);
             await AwaitConditionAsync(() => 
                 testTransport.SystemCalls.Count == 2 
                 && testTransport.SystemCalls[1] == TestStatusTransport.TransportCall.Go);
@@ -163,20 +163,20 @@ namespace Akka.HealthCheck.Tests.Liveness
             // probes reported true, Go should be called all the time
             foreach (var i in Enumerable.Range(2, 8))
             {
-                transportActor.Tell(new LivenessStatus(true), i % 2 == 0 ? fakeLiveness1 : fakeLiveness2);
+                transportActor.Tell(LivenessStatus.Healthy(), i % 2 == 0 ? fakeLiveness1 : fakeLiveness2);
                 await AwaitConditionAsync(() => 
                     testTransport.SystemCalls.Count == i + 1
                     && testTransport.SystemCalls[i] == TestStatusTransport.TransportCall.Go);
             }
             
             // Stop should be called as soon as one of the probe failed
-            transportActor.Tell(new LivenessStatus(false), fakeLiveness1);
+            transportActor.Tell(LivenessStatus.Unhealthy(), fakeLiveness1);
             await AwaitConditionAsync(() => 
                 testTransport.SystemCalls.Count == 11
                 && testTransport.SystemCalls[10] == TestStatusTransport.TransportCall.Stop);
             
             // Go should be called again as soon as the failing probe reports true
-            transportActor.Tell(new LivenessStatus(true), fakeLiveness1);
+            transportActor.Tell(LivenessStatus.Healthy(), fakeLiveness1);
             await AwaitConditionAsync(() => 
                 testTransport.SystemCalls.Count == 12
                 && testTransport.SystemCalls[11] == TestStatusTransport.TransportCall.Go);

--- a/src/Akka.HealthCheck/AkkaHealthStatus.cs
+++ b/src/Akka.HealthCheck/AkkaHealthStatus.cs
@@ -1,0 +1,14 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="HealthStatus.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Akka.HealthCheck;
+
+public enum AkkaHealthStatus
+{
+    Degraded,
+    Unhealthy,
+    Healthy,
+}

--- a/src/Akka.HealthCheck/Liveness/DefaultLivenessProbe.cs
+++ b/src/Akka.HealthCheck/Liveness/DefaultLivenessProbe.cs
@@ -22,7 +22,7 @@ namespace Akka.HealthCheck.Liveness
         private readonly LivenessStatus _livenessStatus;
         private readonly HashSet<IActorRef> _subscribers = new HashSet<IActorRef>();
 
-        public DefaultLivenessProbe() : this(new LivenessStatus(true, $"Live: {DateTimeOffset.UtcNow}"))
+        public DefaultLivenessProbe() : this(LivenessStatus.Healthy($"Live: {DateTimeOffset.UtcNow}"))
         {
            
         }
@@ -58,7 +58,7 @@ namespace Akka.HealthCheck.Liveness
         /// <returns><see cref="Props" /> for a <see cref="DefaultLivenessProbe" /> that will indicate the system is not live.</returns>
         public static Props MisconfiguredProbeProps(string key)
         {
-            return Props.Create(() => new DefaultLivenessProbe(new LivenessStatus(false,
+            return Props.Create(() => new DefaultLivenessProbe(LivenessStatus.Unhealthy(
                 $"akka.healthcheck.liveness.providers.{key} is misconfigured. No suitable type found.")));
         }
     }

--- a/src/Akka.HealthCheck/Liveness/LivenessStatus.cs
+++ b/src/Akka.HealthCheck/Liveness/LivenessStatus.cs
@@ -11,22 +11,34 @@ namespace Akka.HealthCheck.Liveness
     /// </summary>
     public class LivenessStatus
     {
-        public LivenessStatus(bool isLive, string? statusMessage = null)
+        public LivenessStatus(AkkaHealthStatus status, string? statusMessage = null)
         {
-            IsLive = isLive;
+            Status = status;
             StatusMessage = statusMessage ?? string.Empty;
         }
 
+        public virtual bool IsLive => Status is AkkaHealthStatus.Healthy or AkkaHealthStatus.Degraded;
+        
         /// <summary>
-        ///     If <c>true</c>, the current node is live. If <c>false</c>, the current node's
+        ///     Contains the health status of the current node, either Healthy, Degraded, or Unhealthy.
+        ///     If <c>Healthy</c>, the current node is live. If <c>Unhealthy</c>, the current node's
         ///     health is compromised and will likely need to be restarted.
         /// </summary>
-        public virtual bool IsLive { get; }
+        public virtual AkkaHealthStatus Status { get; }
 
         /// <summary>
         ///     An optional status message that will be written out to the
         ///     target (if it supports text) as part of the liveness check.
         /// </summary>
         public virtual string StatusMessage { get; }
+
+        public static LivenessStatus Healthy(string? statusMessage = null)
+            => new(AkkaHealthStatus.Healthy, statusMessage);
+
+        public static LivenessStatus Degraded(string? statusMessage = null)
+            => new(AkkaHealthStatus.Degraded, statusMessage);
+
+        public static LivenessStatus Unhealthy(string? statusMessage = null)
+            => new(AkkaHealthStatus.Unhealthy, statusMessage);
     }
 }

--- a/src/Akka.HealthCheck/Transports/LivenessTransportActor.cs
+++ b/src/Akka.HealthCheck/Transports/LivenessTransportActor.cs
@@ -35,7 +35,7 @@ namespace Akka.HealthCheck.Transports
             foreach (var kvp in livenessProbes)
             {
                 Context.Watch(kvp.Value);
-                _statuses[kvp.Key] = new LivenessStatus(false, $"Probe {kvp.Key} starting up.");
+                _statuses[kvp.Key] = LivenessStatus.Degraded($"Probe {kvp.Key} starting up.");
             }
             _livenessProbes = livenessProbes.Values.ToList();
             _logInfo = log;
@@ -43,35 +43,33 @@ namespace Akka.HealthCheck.Transports
             ReceiveAsync<LivenessStatus>(async status =>
             {
                 var probeName = probeReverseLookup[Sender];
-                using var cts = new CancellationTokenSource(LivenessTimeout);
                 TransportWriteStatus writeStatus;
-                try
+                using(var cts = new CancellationTokenSource(LivenessTimeout))
                 {
-                    if (_logInfo)
-                        _log.Debug("Received liveness status from probe [{0}]. Live: {1}, Message: {2}", probeName, 
-                            status.IsLive, status.StatusMessage);
+                    try
+                    {
+                        if (_logInfo)
+                            _log.Debug("Received liveness status from probe [{0}]. Status: {1}, Message: {2}", probeName, 
+                                status.Status, status.StatusMessage);
                     
-                    _statuses[probeName] = status;
-                    var statusMessage = string.Join(
-                        Environment.NewLine, 
-                        _statuses.Select(kvp => $"[{kvp.Key}][{(kvp.Value.IsLive ? "Live" : "Not Live")}] {kvp.Value.StatusMessage}"));
+                        _statuses[probeName] = status;
+                        var statusMessage = string.Join(
+                            Environment.NewLine, 
+                            _statuses.Select(kvp => $"[{kvp.Key}][{ToStatusString(kvp.Value.Status)}] {kvp.Value.StatusMessage}"));
                     
-                    if (_statuses.Values.All(s => s.IsLive))
-                        writeStatus = await _statusTransport.Go(statusMessage, cts.Token);
-                    else
-                        writeStatus = await _statusTransport.Stop(statusMessage, cts.Token);
-                }
-                catch (Exception e)
-                {
-                    if (_logInfo)
-                        _log.Error(e, $"While processing status from probe [{probeName}]. Failed to write to transport.");
+                        if (_statuses.Values.All(s => s.Status is AkkaHealthStatus.Healthy))
+                            writeStatus = await _statusTransport.Go(statusMessage, cts.Token);
+                        else
+                            writeStatus = await _statusTransport.Stop(statusMessage, cts.Token);
+                    }
+                    catch (Exception e)
+                    {
+                        if (_logInfo)
+                            _log.Error(e, $"While processing status from probe [{probeName}]. Failed to write to transport.");
 
-                    throw new ProbeUpdateException(ProbeKind.Liveness,
-                        $"While processing status from probe [{probeName}]. Failed to update underlying transport {_statusTransport}", e);
-                }
-                finally
-                {
-                    cts.Dispose();
+                        throw new ProbeUpdateException(ProbeKind.Liveness,
+                            $"While processing status from probe [{probeName}]. Failed to update underlying transport {_statusTransport}", e);
+                    }
                 }
 
                 if (!writeStatus.Success)
@@ -82,6 +80,16 @@ namespace Akka.HealthCheck.Transports
                     throw new ProbeUpdateException(ProbeKind.Liveness,
                         $"While processing status from probe [{probeName}]. Failed to update underlying transport {_statusTransport}", writeStatus.Exception);
                 }
+
+                return;
+
+                string ToStatusString(AkkaHealthStatus s)
+                    => s switch
+                    {
+                        AkkaHealthStatus.Healthy => "Live",
+                        AkkaHealthStatus.Unhealthy => "Not Live",
+                        _ => "Degraded"
+                    };
             });
 
             Receive<Terminated>(t =>
@@ -98,7 +106,7 @@ namespace Akka.HealthCheck.Transports
                 }
                 else
                 {
-                    Self.Tell(new LivenessStatus(false, "Probe terminated"), t.ActorRef);
+                    Self.Tell(LivenessStatus.Unhealthy("Probe terminated"), t.ActorRef);
                 }
             });
         }


### PR DESCRIPTION
* Make liveness status a tri-state instead of a boolean
* Make Akka.Healthcheck.Persistence returns `Degraded` instead of `Unhealthy` status during warmup