### PR TITLE
Add custom persistence test kit

### DIFF
--- a/Akka.HealthCheck.Persistence.TestKit/Akka.HealthCheck.Persistence.TestKit.csproj
+++ b/Akka.HealthCheck.Persistence.TestKit/Akka.HealthCheck.Persistence.TestKit.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Akka.Persistence" Version="1.5.26" />
+    <PackageReference Include="Akka.TestKit" Version="1.5.26" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.5.26" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="config.conf" />
+  </ItemGroup>
+
+</Project>

--- a/Akka.HealthCheck.Persistence.TestKit/ConnectionInterceptors.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/ConnectionInterceptors.cs
@@ -1,0 +1,109 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ConnectionInterceptors.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.HealthCheck.Persistence.TestKit.Journal;
+
+namespace Akka.HealthCheck.Persistence.TestKit;
+
+public class ConnectionInterceptors
+{
+    public class Noop : IConnectionInterceptor
+    {
+        public static readonly IConnectionInterceptor Instance = new Noop();
+
+        public Task InterceptAsync() => Task.FromResult(true);
+    }
+
+    public class Failure : IConnectionInterceptor
+    {
+        public static readonly IConnectionInterceptor Instance = new Failure();
+
+        public Task InterceptAsync() => throw new TestConnectionException(); 
+    }
+
+    public class Delay : IConnectionInterceptor
+    {
+        public Delay(TimeSpan delay, IConnectionInterceptor next)
+        {
+            _delay = delay;
+            _next = next;
+        }
+
+        private readonly TimeSpan _delay;
+        private readonly IConnectionInterceptor _next;
+
+        public async Task InterceptAsync()
+        {
+            await Task.Delay(_delay);
+            await _next.InterceptAsync();
+        }
+    }
+
+    public sealed class OnCondition : IConnectionInterceptor
+    {
+        public OnCondition(Func<Task<bool>> predicate, IConnectionInterceptor next, bool negate = false)
+        {
+            _predicate = predicate;
+            _next = next;
+            _negate = negate;
+        }
+
+        public OnCondition(Func<bool> predicate, IConnectionInterceptor next, bool negate = false)
+        {
+            _predicate = () => Task.FromResult(predicate());
+            _next = next;
+            _negate = negate;
+        }
+
+        private readonly Func<Task<bool>> _predicate;
+        private readonly IConnectionInterceptor _next;
+        private readonly bool _negate;
+
+        public async Task InterceptAsync()
+        {
+            var result = await _predicate();
+            if ((_negate && !result) || (!_negate && result))
+            {
+                await _next.InterceptAsync();
+            }
+        }
+    }
+    
+    public class CancelableDelay: IConnectionInterceptor
+    {
+        public CancelableDelay(TimeSpan delay, IConnectionInterceptor next, CancellationToken cancellationToken)
+        {
+            _delay = delay;
+            _next = next;
+            _cancellationToken = cancellationToken;
+        }
+
+        private readonly TimeSpan _delay;
+        private readonly IConnectionInterceptor _next;
+        private readonly CancellationToken _cancellationToken;
+
+        public async Task InterceptAsync()
+        {
+            try
+            {
+                await Task.Delay(_delay, _cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // no-op
+            }
+            catch (TimeoutException)
+            {
+                // no-op
+            }
+            await _next.InterceptAsync();
+        }
+    }    
+
+}

--- a/Akka.HealthCheck.Persistence.TestKit/IConnectionInterceptor.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/IConnectionInterceptor.cs
@@ -1,0 +1,14 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="IConnectionInterceptor.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+
+namespace Akka.HealthCheck.Persistence.TestKit;
+
+public interface IConnectionInterceptor
+{
+    Task InterceptAsync();
+}

--- a/Akka.HealthCheck.Persistence.TestKit/Journal/IJournalBehaviorSetter.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/Journal/IJournalBehaviorSetter.cs
@@ -1,0 +1,15 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="IJournalBehaviorSetter.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+
+namespace Akka.HealthCheck.Persistence.TestKit.Journal;
+
+public interface IJournalBehaviorSetter
+{
+    Task SetInterceptorAsync(IJournalInterceptor interceptor);
+}

--- a/Akka.HealthCheck.Persistence.TestKit/Journal/IJournalConnectionBehaviorSetter.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/Journal/IJournalConnectionBehaviorSetter.cs
@@ -1,0 +1,14 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="IConnectionBehaviorSetter.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+
+namespace Akka.HealthCheck.Persistence.TestKit.Journal;
+
+public interface IJournalConnectionBehaviorSetter
+{
+    Task SetInterceptorAsync(IConnectionInterceptor interceptor);
+}

--- a/Akka.HealthCheck.Persistence.TestKit/Journal/IJournalInterceptor.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/Journal/IJournalInterceptor.cs
@@ -1,0 +1,23 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="IJournalInterceptor.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Akka.Persistence;
+
+namespace Akka.HealthCheck.Persistence.TestKit.Journal;
+
+/// <summary>
+///     Interface to object which will intercept written and recovered messages in <see cref="TestJournal"/>.
+/// </summary>
+public interface IJournalInterceptor
+{
+    /// <summary>
+    ///     Method will be called for each individual message before it is written or recovered.
+    /// </summary>
+    /// <param name="message">Written or recovered message.</param>
+    Task InterceptAsync(IPersistentRepresentation message);
+}

--- a/Akka.HealthCheck.Persistence.TestKit/Journal/ITestJournal.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/Journal/ITestJournal.cs
@@ -1,0 +1,26 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ITestJournal.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Akka.HealthCheck.Persistence.TestKit.Journal;
+
+/// <summary>
+///     <see cref="TestJournal"/> proxy object interface. Used to simplify communication with <see cref="TestJournal"/> actor instance.
+/// </summary>
+public interface ITestJournal
+{
+    /// <summary>
+    ///     List of interceptors to alter write behavior of proxied journal.
+    /// </summary>
+    JournalWriteBehavior OnWrite { get; }
+        
+    /// <summary>
+    ///     List of interceptors to alter recovery behavior of proxied journal.
+    /// </summary>
+    JournalRecoveryBehavior OnRecovery { get; }
+        
+    JournalConnectionBehavior OnConnect { get; }
+}

--- a/Akka.HealthCheck.Persistence.TestKit/Journal/JournalConnectionBehavior.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/Journal/JournalConnectionBehavior.cs
@@ -1,0 +1,309 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="JournalRecoveryBehavior.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Persistence;
+
+namespace Akka.HealthCheck.Persistence.TestKit.Journal;
+
+/// <summary>
+///     Built-in Journal interceptors who will alter messages Recovery and/or Write of <see cref="TestJournal"/>.
+/// </summary>
+public class JournalConnectionBehavior
+{
+    internal JournalConnectionBehavior(IJournalConnectionBehaviorSetter setter)
+    {
+        Setter = setter;
+    }
+
+    private IJournalConnectionBehaviorSetter Setter { get; }
+
+    /// <summary>
+    ///     Use custom, user defined interceptor.
+    /// </summary>
+    /// <param name="interceptor">User defined interceptor which implements <see cref="IJournalInterceptor"/> interface.</param>
+    /// <exception cref="ArgumentNullException">When <paramref name="interceptor"/> is <c>null</c>.</exception>
+    public Task SetInterceptorAsync(IConnectionInterceptor interceptor)
+    {
+        if (interceptor == null) throw new ArgumentNullException(nameof(interceptor));
+
+        return Setter.SetInterceptorAsync(interceptor);
+    }
+
+    /// <summary>
+    ///     Pass all messages to journal without interfering.
+    /// </summary>
+    /// <remarks>
+    ///     By using this interceptor <see cref="TestJournal"/> all journal operations will work like
+    ///     in standard <see cref="Akka.Persistence.Journal.MemoryJournal"/>.
+    /// </remarks>
+    public Task Pass() => SetInterceptorAsync(ConnectionInterceptors.Noop.Instance);
+
+    /// <summary>
+    ///     Delay passing all messages to journal by <paramref name="delay"/>.
+    /// </summary>
+    /// <remarks>
+    ///     Each message will be delayed individually.
+    /// </remarks>
+    /// <param name="delay">Time by which recovery operation will be delayed.</param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    public Task PassWithDelay(TimeSpan delay)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+
+        return SetInterceptorAsync(new ConnectionInterceptors.Delay(delay, ConnectionInterceptors.Noop.Instance));
+    }
+
+    /// <summary>
+    ///     Always fail all messages.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    public Task Fail() => SetInterceptorAsync(ConnectionInterceptors.Failure.Instance);
+
+    /// <summary>
+    ///     Fail message if predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailIf(Func<bool> predicate)
+    {
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new ConnectionInterceptors.OnCondition(predicate, ConnectionInterceptors.Failure.Instance));
+    }
+
+    /// <summary>
+    ///     Fail message if async predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailIf(Func<Task<bool>> predicate)
+    {
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new ConnectionInterceptors.OnCondition(predicate, ConnectionInterceptors.Failure.Instance));
+    }
+
+    /// <summary>
+    ///     Fail message unless predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailUnless(Func<bool> predicate)
+    {
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new ConnectionInterceptors.OnCondition(predicate, ConnectionInterceptors.Failure.Instance, negate: true));
+    }
+
+    /// <summary>
+    ///     Fail message unless async predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailUnless(Func<Task<bool>> predicate)
+    {
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new ConnectionInterceptors.OnCondition(predicate, ConnectionInterceptors.Failure.Instance, negate: true));
+    }
+
+    /// <summary>
+    ///     Fail message after specified delay.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    public Task FailWithDelay(TimeSpan delay)
+    {
+        if (delay <= TimeSpan.Zero)  throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+
+        return SetInterceptorAsync(new ConnectionInterceptors.Delay(delay, ConnectionInterceptors.Failure.Instance));
+    }
+
+    /// <summary>
+    ///     Fail message after specified delay if async predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailIfWithDelay(TimeSpan delay, Func<Task<bool>> predicate)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new ConnectionInterceptors.OnCondition(
+            predicate, 
+            new ConnectionInterceptors.Delay(delay, ConnectionInterceptors.Failure.Instance)
+        ));
+    }
+
+    /// <summary>
+    ///     Fail message after specified delay if predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailIfWithDelay(TimeSpan delay, Func<bool> predicate)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new ConnectionInterceptors.OnCondition(
+            predicate, 
+            new ConnectionInterceptors.Delay(delay, ConnectionInterceptors.Failure.Instance)
+        ));
+    }
+
+    /// <summary>
+    ///     Fail message after specified delay unless predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailUnlessWithDelay(TimeSpan delay, Func<bool> predicate)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new ConnectionInterceptors.OnCondition(
+            predicate, 
+            new ConnectionInterceptors.Delay(delay, ConnectionInterceptors.Failure.Instance),
+            negate: true
+        ));
+    }
+
+    /// <summary>
+    ///     Fail message after specified delay unless async predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailUnlessWithDelay(TimeSpan delay, Func<Task<bool>> predicate)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            
+        return SetInterceptorAsync(new ConnectionInterceptors.OnCondition(
+            predicate, 
+            new ConnectionInterceptors.Delay(delay, ConnectionInterceptors.Failure.Instance),
+            negate: true
+        ));
+    }
+}

--- a/Akka.HealthCheck.Persistence.TestKit/Journal/JournalConnectionBehaviorSetter.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/Journal/JournalConnectionBehaviorSetter.cs
@@ -1,0 +1,31 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="JournalRecoveryBehaviorSetter.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+
+namespace Akka.HealthCheck.Persistence.TestKit.Journal;
+
+/// <summary>
+/// Setter strategy for TestJournal which will set recovery interceptor.
+/// </summary>
+internal class JournalConnectionBehaviorSetter : IJournalConnectionBehaviorSetter
+{
+    internal JournalConnectionBehaviorSetter(IActorRef journal)
+    {
+        _journal = journal;
+    }
+
+    private readonly IActorRef _journal;
+
+    public Task SetInterceptorAsync(IConnectionInterceptor interceptor)
+        => _journal.Ask<TestJournal.Ack>(
+            new TestJournal.UseConnectionInterceptor(interceptor),
+            TimeSpan.FromSeconds(3)
+        );
+}

--- a/Akka.HealthCheck.Persistence.TestKit/Journal/JournalInterceptors.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/Journal/JournalInterceptors.cs
@@ -1,0 +1,139 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="JournalInterceptors.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Persistence;
+
+namespace Akka.HealthCheck.Persistence.TestKit.Journal;
+
+public static class JournalInterceptors
+{
+    public class Noop : IJournalInterceptor
+    {
+        public static readonly IJournalInterceptor Instance = new Noop();
+
+        public Task InterceptAsync(IPersistentRepresentation message) => Task.FromResult(true);
+    }
+
+    public class Failure : IJournalInterceptor
+    {
+        public static readonly IJournalInterceptor Instance = new Failure();
+
+        public Task InterceptAsync(IPersistentRepresentation message) => throw new TestJournalFailureException(); 
+    }
+
+    public class Rejection : IJournalInterceptor
+    {
+        public static readonly IJournalInterceptor Instance = new Rejection();
+
+        public Task InterceptAsync(IPersistentRepresentation message) => throw new TestJournalRejectionException(); 
+    }
+        
+    public class Delay : IJournalInterceptor
+    {
+        public Delay(TimeSpan delay, IJournalInterceptor next)
+        {
+            _delay = delay;
+            _next = next;
+        }
+
+        private readonly TimeSpan _delay;
+        private readonly IJournalInterceptor _next;
+
+        public async Task InterceptAsync(IPersistentRepresentation message)
+        {
+            await Task.Delay(_delay);
+            await _next.InterceptAsync(message);
+        }
+    }
+
+    public sealed class OnCondition : IJournalInterceptor
+    {
+        public OnCondition(Func<IPersistentRepresentation, Task<bool>> predicate, IJournalInterceptor next, bool negate = false)
+        {
+            _predicate = predicate;
+            _next = next;
+            _negate = negate;
+        }
+
+        public OnCondition(Func<IPersistentRepresentation, bool> predicate, IJournalInterceptor next, bool negate = false)
+        {
+            _predicate = message => Task.FromResult(predicate(message));
+            _next = next;
+            _negate = negate;
+        }
+
+        private readonly Func<IPersistentRepresentation, Task<bool>> _predicate;
+        private readonly IJournalInterceptor _next;
+        private readonly bool _negate;
+
+        public async Task InterceptAsync(IPersistentRepresentation message)
+        {
+            var result = await _predicate(message);
+            if ((_negate && !result) || (!_negate && result))
+            {
+                await _next.InterceptAsync(message);
+            }
+        }
+    }
+
+    public class OnType : IJournalInterceptor
+    {
+        public OnType(Type messageType, IJournalInterceptor next)
+        {
+            _messageType = messageType;
+            _next = next;
+        }
+
+        private readonly Type _messageType;
+        private readonly IJournalInterceptor _next;
+
+        public async Task InterceptAsync(IPersistentRepresentation message)
+        {
+            var type = message.Payload.GetType();
+
+            if (_messageType.IsAssignableFrom(type))
+            {
+                await _next.InterceptAsync(message);
+            }
+        }
+    }
+    
+    public class CancelableDelay: IJournalInterceptor
+    {
+        public CancelableDelay(TimeSpan delay, IJournalInterceptor next, CancellationToken cancellationToken)
+        {
+            _delay = delay;
+            _next = next;
+            _cancellationToken = cancellationToken;
+        }
+
+        private readonly TimeSpan _delay;
+        private readonly IJournalInterceptor _next;
+        private readonly CancellationToken _cancellationToken;
+
+        public async Task InterceptAsync(IPersistentRepresentation message)
+        {
+            try
+            {
+                await Task.Delay(_delay, _cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // no-op
+            }
+            catch (TimeoutException)
+            {
+                // no-op
+            }
+            await _next.InterceptAsync(message);
+        }
+    }    
+    
+}

--- a/Akka.HealthCheck.Persistence.TestKit/Journal/JournalRecoveryBehavior.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/Journal/JournalRecoveryBehavior.cs
@@ -1,0 +1,419 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="JournalRecoveryBehavior.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Persistence;
+
+namespace Akka.HealthCheck.Persistence.TestKit.Journal;
+
+/// <summary>
+///     Built-in Journal interceptors who will alter messages Recovery and/or Write of <see cref="TestJournal"/>.
+/// </summary>
+public class JournalRecoveryBehavior
+{
+    internal JournalRecoveryBehavior(IJournalBehaviorSetter setter)
+    {
+            Setter = setter;
+        }
+
+    private IJournalBehaviorSetter Setter { get; }
+
+    /// <summary>
+    ///     Use custom, user defined interceptor.
+    /// </summary>
+    /// <param name="interceptor">User defined interceptor which implements <see cref="IJournalInterceptor"/> interface.</param>
+    /// <exception cref="ArgumentNullException">When <paramref name="interceptor"/> is <c>null</c>.</exception>
+    public Task SetInterceptorAsync(IJournalInterceptor interceptor)
+    {
+            if (interceptor == null) throw new ArgumentNullException(nameof(interceptor));
+
+            return Setter.SetInterceptorAsync(interceptor);
+        }
+
+    /// <summary>
+    ///     Pass all messages to journal without interfering.
+    /// </summary>
+    /// <remarks>
+    ///     By using this interceptor <see cref="TestJournal"/> all journal operations will work like
+    ///     in standard <see cref="Akka.Persistence.Journal.MemoryJournal"/>.
+    /// </remarks>
+    public Task Pass() => SetInterceptorAsync(JournalInterceptors.Noop.Instance);
+
+    /// <summary>
+    ///     Delay passing all messages to journal by <paramref name="delay"/>.
+    /// </summary>
+    /// <remarks>
+    ///     Each message will be delayed individually.
+    /// </remarks>
+    /// <param name="delay">Time by which recovery operation will be delayed.</param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    public Task PassWithDelay(TimeSpan delay)
+    {
+            if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+
+            return SetInterceptorAsync(new JournalInterceptors.Delay(delay, JournalInterceptors.Noop.Instance));
+        }
+
+    /// <summary>
+    ///     Always fail all messages.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    public Task Fail() => SetInterceptorAsync(JournalInterceptors.Failure.Instance);
+
+    /// <summary>
+    ///     Fail message during processing message of type <typeparamref name="TMessage"/>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    ///     <para>
+    ///         <list type="bullet">
+    ///             <item>If <typeparamref name="TMessage"/> is interface, journal will fail when message implements that interface.</item>
+    ///             <item>If <typeparamref name="TMessage"/> is class, journal will fail when message can be assigned to <typeparamref name="TMessage"/>.</item>
+    ///         </list>
+    ///     </para>
+    /// </remarks>
+    /// <typeparam name="TMessage"></typeparam>
+    public Task FailOnType<TMessage>() => FailOnType(typeof(TMessage));
+
+    /// <summary>
+    ///     Fail message during processing message of type <paramref name="messageType"/>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    ///     <para>
+    ///         <list type="bullet">
+    ///             <item>If <paramref name="messageType"/> is interface, journal will fail when message implements that interface.</item>
+    ///             <item>If <paramref name="messageType"/> is class, journal will fail when message can be assigned to <paramref name="messageType"/>.</item>
+    ///         </list>
+    ///     </para>
+    /// </remarks>
+    /// <param name="messageType"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="messageType"/> is <c>null</c>.</exception>
+    public Task FailOnType(Type messageType)
+    {
+            if (messageType == null) throw new ArgumentNullException(nameof(messageType));
+
+            return SetInterceptorAsync(new JournalInterceptors.OnType(messageType, JournalInterceptors.Failure.Instance));
+        }
+
+    /// <summary>
+    ///     Fail message if predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailIf(Func<IPersistentRepresentation, bool> predicate)
+    {
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return SetInterceptorAsync(new JournalInterceptors.OnCondition(predicate, JournalInterceptors.Failure.Instance));
+        }
+
+    /// <summary>
+    ///     Fail message if async predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailIf(Func<IPersistentRepresentation, Task<bool>> predicate)
+    {
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return SetInterceptorAsync(new JournalInterceptors.OnCondition(predicate, JournalInterceptors.Failure.Instance));
+        }
+
+    /// <summary>
+    ///     Fail message unless predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailUnless(Func<IPersistentRepresentation, bool> predicate)
+    {
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return SetInterceptorAsync(new JournalInterceptors.OnCondition(predicate, JournalInterceptors.Failure.Instance, negate: true));
+        }
+
+    /// <summary>
+    ///     Fail message unless async predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailUnless(Func<IPersistentRepresentation, Task<bool>> predicate)
+    {
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return SetInterceptorAsync(new JournalInterceptors.OnCondition(predicate, JournalInterceptors.Failure.Instance, negate: true));
+        }
+
+    /// <summary>
+    ///     Fail message after specified delay.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    public Task FailWithDelay(TimeSpan delay)
+    {
+            if (delay <= TimeSpan.Zero)  throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+
+            return SetInterceptorAsync(new JournalInterceptors.Delay(delay, JournalInterceptors.Failure.Instance));
+        }
+
+    /// <summary>
+    ///     Fail message after specified delay if async predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailIfWithDelay(TimeSpan delay, Func<IPersistentRepresentation, Task<bool>> predicate)
+    {
+            if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return SetInterceptorAsync(new JournalInterceptors.OnCondition(
+                predicate, 
+                new JournalInterceptors.Delay(delay, JournalInterceptors.Failure.Instance)
+            ));
+        }
+
+    /// <summary>
+    ///     Fail message after specified delay if predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailIfWithDelay(TimeSpan delay, Func<IPersistentRepresentation, bool> predicate)
+    {
+            if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return SetInterceptorAsync(new JournalInterceptors.OnCondition(
+                predicate, 
+                new JournalInterceptors.Delay(delay, JournalInterceptors.Failure.Instance)
+            ));
+        }
+
+    /// <summary>
+    ///     Fail message after specified delay unless predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailUnlessWithDelay(TimeSpan delay, Func<IPersistentRepresentation, bool> predicate)
+    {
+            if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return SetInterceptorAsync(new JournalInterceptors.OnCondition(
+                predicate, 
+                new JournalInterceptors.Delay(delay, JournalInterceptors.Failure.Instance),
+                negate: true
+            ));
+        }
+
+    /// <summary>
+    ///     Fail message after specified delay unless async predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailUnlessWithDelay(TimeSpan delay, Func<IPersistentRepresentation, Task<bool>> predicate)
+    {
+            if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            
+            return SetInterceptorAsync(new JournalInterceptors.OnCondition(
+                predicate, 
+                new JournalInterceptors.Delay(delay, JournalInterceptors.Failure.Instance),
+                negate: true
+            ));
+        }
+
+    /// <summary>
+    ///     Fail message after specified delay if recovering message of type <typeparamref name="TMessage"/>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    ///     <para>
+    ///         <list type="bullet">
+    ///             <item>If <typeparamref name="TMessage"/> is interface, journal will fail when message implements that interface.</item>
+    ///             <item>If <typeparamref name="TMessage"/> is class, journal will fail when message can be assigned to <typeparamref name="TMessage"/>.</item>
+    ///         </list>
+    ///     </para>
+    /// </remarks>
+    /// <typeparam name="TMessage"></typeparam>
+    /// <param name="delay"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    public Task FailOnTypeWithDelay<TMessage>(TimeSpan delay) => FailOnTypeWithDelay(delay, typeof(TMessage));
+
+    /// <summary>
+    ///     Fail message after specified delay if recovering message of type <paramref name="messageType"/>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    ///     <para>
+    ///         <list type="bullet">
+    ///             <item>If <paramref name="messageType"/> is interface, journal will fail when message implements that interface.</item>
+    ///             <item>If <paramref name="messageType"/> is class, journal will fail when message can be assigned to <paramref name="messageType"/>.</item>
+    ///         </list>
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="messageType"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="messageType"/> is <c>null</c>.</exception>
+    public Task FailOnTypeWithDelay(TimeSpan delay, Type messageType)
+    {
+            if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+            if (messageType == null) throw new ArgumentNullException(nameof(messageType));
+
+            return SetInterceptorAsync(new JournalInterceptors.OnType(
+                messageType, 
+                new JournalInterceptors.Delay(delay, JournalInterceptors.Failure.Instance)
+            ));
+        }
+}

--- a/Akka.HealthCheck.Persistence.TestKit/Journal/JournalRecoveryBehaviorSetter.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/Journal/JournalRecoveryBehaviorSetter.cs
@@ -1,0 +1,31 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="JournalRecoveryBehaviorSetter.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+
+namespace Akka.HealthCheck.Persistence.TestKit.Journal;
+
+/// <summary>
+/// Setter strategy for TestJournal which will set recovery interceptor.
+/// </summary>
+internal class JournalRecoveryBehaviorSetter : IJournalBehaviorSetter
+{
+    internal JournalRecoveryBehaviorSetter(IActorRef journal)
+    {
+            _journal = journal;
+        }
+
+    private readonly IActorRef _journal;
+
+    public Task SetInterceptorAsync(IJournalInterceptor interceptor)
+        => _journal.Ask<TestJournal.Ack>(
+            new TestJournal.UseRecoveryInterceptor(interceptor),
+            TimeSpan.FromSeconds(3)
+        );
+}

--- a/Akka.HealthCheck.Persistence.TestKit/Journal/JournalWriteBehavior.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/Journal/JournalWriteBehavior.cs
@@ -1,0 +1,392 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="JournalWriteBehavior.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Persistence;
+
+namespace Akka.HealthCheck.Persistence.TestKit.Journal;
+
+/// <summary>
+///     Built-in Journal interceptors who will alter message Write of <see cref="TestJournal"/>.
+/// </summary>
+public class JournalWriteBehavior : JournalRecoveryBehavior
+{
+    internal JournalWriteBehavior(IJournalBehaviorSetter setter) : base(setter) { }
+
+    /// <summary>
+    ///     Always reject all messages.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
+    ///         on each rejected message.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle serialization,
+    ///         type conversion and other local problems withing journal.
+    ///     </para>
+    /// </remarks>
+    public Task Reject() => SetInterceptorAsync(JournalInterceptors.Rejection.Instance);
+
+    /// <summary>
+    ///     Reject message during processing message of type <typeparamref name="TMessage"/>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
+    ///         on each rejected message.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle serialization,
+    ///         type conversion and other local problems withing journal.
+    ///     </para>
+    ///     <para>
+    ///         <list type="bullet">
+    ///             <item>If <typeparamref name="TMessage"/> is interface, journal will reject when message implements that interface.</item>
+    ///             <item>If <typeparamref name="TMessage"/> is class, journal will reject when message can be assigned to <typeparamref name="TMessage"/>.</item>
+    ///         </list>
+    ///     </para>
+    /// </remarks>
+    /// <typeparam name="TMessage"></typeparam>
+    public Task RejectOnType<TMessage>() => FailOnType(typeof(TMessage));
+
+    /// <summary>
+    ///     Reject message during processing message of type <paramref name="messageType"/>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see>> will be called
+    ///         on each rejected message.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle serialization,
+    ///         type conversion and other local problems withing journal.
+    ///     </para>
+    ///     <para>
+    ///         <list type="bullet">
+    ///             <item>If <paramref name="messageType"/> is interface, journal will reject when message implements that interface.</item>
+    ///             <item>If <paramref name="messageType"/> is class, journal will reject when message can be assigned to <paramref name="messageType"/>.</item>
+    ///         </list>
+    ///     </para>
+    /// </remarks>
+    /// <param name="messageType"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="messageType"/> is <c>null</c>.</exception>
+    public Task RejectOnType(Type messageType)
+    {
+        if (messageType == null) throw new ArgumentNullException(nameof(messageType));
+
+        return SetInterceptorAsync(new JournalInterceptors.OnType(messageType, JournalInterceptors.Rejection.Instance));
+    }
+
+    /// <summary>
+    ///     Reject message if predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
+    ///         on each rejected message.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle serialization,
+    ///         type conversion and other local problems withing journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task RejectIf(Func<IPersistentRepresentation, bool> predicate)
+    {
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new JournalInterceptors.OnCondition(predicate, JournalInterceptors.Rejection.Instance));
+    }
+
+    /// <summary>
+    ///     Reject message if async predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
+    ///         on each rejected message.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle serialization,
+    ///         type conversion and other local problems withing journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task RejectIf(Func<IPersistentRepresentation, Task<bool>> predicate)
+    {
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new JournalInterceptors.OnCondition(predicate, JournalInterceptors.Rejection.Instance));
+    }
+
+    /// <summary>
+    ///     Reject message unless predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
+    ///         on each rejected message.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle serialization,
+    ///         type conversion and other local problems withing journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task RejectUnless(Func<IPersistentRepresentation, bool> predicate)
+    {
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new JournalInterceptors.OnCondition(predicate, JournalInterceptors.Rejection.Instance, negate: true));
+    }
+
+    /// <summary>
+    ///     Reject message unless async predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
+    ///         on each rejected message.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle serialization,
+    ///         type conversion and other local problems withing journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task RejectUnless(Func<IPersistentRepresentation, Task<bool>> predicate)
+    {
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new JournalInterceptors.OnCondition(predicate, JournalInterceptors.Rejection.Instance, negate: true));
+    }
+
+    /// <summary>
+    ///     Reject message after specified delay.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
+    ///         on each rejected message.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle serialization,
+    ///         type conversion and other local problems withing journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    public Task RejectWithDelay(TimeSpan delay)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+
+        return SetInterceptorAsync(new JournalInterceptors.Delay(delay, JournalInterceptors.Rejection.Instance));
+    }
+
+    /// <summary>
+    ///     Reject message after specified delay if async predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
+    ///         on each rejected message.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle serialization,
+    ///         type conversion and other local problems withing journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task RejectIfWithDelay(TimeSpan delay, Func<IPersistentRepresentation, Task<bool>> predicate)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new JournalInterceptors.OnCondition(
+            predicate, 
+            new JournalInterceptors.Delay(delay, JournalInterceptors.Rejection.Instance)
+        ));
+    }
+
+    /// <summary>
+    ///     Reject message after specified delay if predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
+    ///         on each rejected message.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle serialization,
+    ///         type conversion and other local problems withing journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task RejectIfWithDelay(TimeSpan delay, Func<IPersistentRepresentation, bool> predicate)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new JournalInterceptors.OnCondition(
+            predicate, 
+            new JournalInterceptors.Delay(delay, JournalInterceptors.Rejection.Instance)
+        ));
+    }
+
+    /// <summary>
+    ///     Reject message after specified delay unless predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
+    ///         on each rejected message.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle serialization,
+    ///         type conversion and other local problems withing journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task RejectUnlessWithDelay(TimeSpan delay, Func<IPersistentRepresentation, bool> predicate)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new JournalInterceptors.OnCondition(
+            predicate, 
+            new JournalInterceptors.Delay(delay, JournalInterceptors.Rejection.Instance),
+            negate: true
+        ));
+    }
+
+    /// <summary>
+    ///     Reject message after specified delay unless async predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
+    ///         on each rejected message.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle serialization,
+    ///         type conversion and other local problems withing journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task RejectUnlessWithDelay(TimeSpan delay, Func<IPersistentRepresentation, Task<bool>> predicate)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            
+        return SetInterceptorAsync(new JournalInterceptors.OnCondition(
+            predicate, 
+            new JournalInterceptors.Delay(delay, JournalInterceptors.Rejection.Instance),
+            negate: true
+        ));
+    }
+
+    /// <summary>
+    ///     Reject message after specified delay if recovering message of type <typeparamref name="TMessage"/>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
+    ///         on each rejected message.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle serialization,
+    ///         type conversion and other local problems withing journal.
+    ///     </para>
+    ///     <para>
+    ///         <list type="bullet">
+    ///             <item>If <typeparamref name="TMessage"/> is interface, journal will reject when message implements that interface.</item>
+    ///             <item>If <typeparamref name="TMessage"/> is class, journal will reject when message can be assigned to <typeparamref name="TMessage"/>.</item>
+    ///         </list>
+    ///     </para>
+    /// </remarks>
+    /// <typeparam name="TMessage"></typeparam>
+    /// <param name="delay"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    public Task RejectOnTypeWithDelay<TMessage>(TimeSpan delay) => FailOnTypeWithDelay(delay, typeof(TMessage));
+
+    /// <summary>
+    ///     Reject message after specified delay if recovering message of type <paramref name="messageType"/>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
+    ///         on each rejected message.
+    ///     </para>
+    ///     <para>
+    ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle serialization,
+    ///         type conversion and other local problems withing journal.
+    ///     </para>
+    ///     <para>
+    ///         <list type="bullet">
+    ///             <item>If <paramref name="messageType"/> is interface, journal will reject when message implements that interface.</item>
+    ///             <item>If <paramref name="messageType"/> is class, journal will reject when message can be assigned to <paramref name="messageType"/>.</item>
+    ///         </list>
+    ///     </para>
+    /// </remarks>
+    /// <param name="messageType"></param>
+    /// <param name="delay"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="messageType"/> is <c>null</c>.</exception>
+    public Task RejectOnTypeWithDelay(TimeSpan delay, Type messageType)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+        if (messageType == null) throw new ArgumentNullException(nameof(messageType));
+
+        return SetInterceptorAsync(new JournalInterceptors.OnType(
+            messageType, 
+            new JournalInterceptors.Delay(delay, JournalInterceptors.Rejection.Instance)
+        ));
+    }
+}

--- a/Akka.HealthCheck.Persistence.TestKit/Journal/JournalWriteBehaviorSetter.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/Journal/JournalWriteBehaviorSetter.cs
@@ -1,0 +1,31 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="JournalWriteBehaviorSetter.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+
+namespace Akka.HealthCheck.Persistence.TestKit.Journal;
+
+/// <summary>
+///     Setter strategy for <see cref="TestJournal"/> which will set write interceptor.
+/// </summary>
+internal class JournalWriteBehaviorSetter : IJournalBehaviorSetter
+{
+    internal JournalWriteBehaviorSetter(IActorRef journal)
+    {
+        _journal = journal;
+    }
+
+    private readonly IActorRef _journal;
+
+    public Task SetInterceptorAsync(IJournalInterceptor interceptor)
+        => _journal.Ask<TestJournal.Ack>(
+            new TestJournal.UseWriteInterceptor(interceptor),
+            TimeSpan.FromSeconds(3)
+        );
+}

--- a/Akka.HealthCheck.Persistence.TestKit/Journal/TestJournal.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/Journal/TestJournal.cs
@@ -1,0 +1,175 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TestJournal.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Persistence;
+using Akka.Persistence.Journal;
+
+namespace Akka.HealthCheck.Persistence.TestKit.Journal;
+
+/// <summary>
+///     In-memory persistence journal implementation which behavior could be controlled by interceptors.
+/// </summary>
+public sealed class TestJournal : MemoryJournal
+{
+    private IJournalInterceptor _writeInterceptor = JournalInterceptors.Noop.Instance;
+    private IJournalInterceptor _recoveryInterceptor = JournalInterceptors.Noop.Instance;
+    private IConnectionInterceptor _connectionInterceptor = ConnectionInterceptors.Noop.Instance;
+
+    protected override bool ReceivePluginInternal(object message)
+    {
+        switch (message)
+        {
+            case UseWriteInterceptor use:
+                _writeInterceptor = use.Interceptor;
+                Sender.Tell(Ack.Instance);
+                return true;
+
+            case UseRecoveryInterceptor use:
+                _recoveryInterceptor = use.Interceptor;
+                Sender.Tell(Ack.Instance);
+                return true;
+            
+            case UseConnectionInterceptor use:
+                _connectionInterceptor = use.Interceptor;
+                Sender.Tell(Ack.Instance);
+                return true;
+            
+            default:
+                return base.ReceivePluginInternal(message);
+        }
+    }
+
+    protected override async Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+    {
+        await _connectionInterceptor.InterceptAsync();
+        var exceptions = new List<Exception>();
+        foreach (var w in messages)
+        {
+            try
+            {
+                foreach (var p in (IEnumerable<IPersistentRepresentation>)w.Payload)
+                {
+                    await _writeInterceptor.InterceptAsync(p);
+                    Add(p);
+                }
+            }
+            catch (TestJournalRejectionException rejected)
+            {
+                // i.e. problems with data: corrupted data-set, problems in serialization, constraints, etc.
+                exceptions.Add(rejected);
+                continue;
+            }
+            catch (TestJournalFailureException)
+            {
+                // i.e. data-store problems: network, invalid credentials, etc.
+                throw;
+            }
+            exceptions.Add(null);
+        }
+
+        return exceptions.ToImmutableList();
+    }
+
+    public override async Task ReplayMessagesAsync(IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, Action<IPersistentRepresentation> recoveryCallback)
+    {
+        await _connectionInterceptor.InterceptAsync();
+        var highest = HighestSequenceNr(persistenceId);
+        if (highest != 0L && max != 0L)
+        {
+            var messages = Read(persistenceId, fromSequenceNr, Math.Min(toSequenceNr, highest), max);
+            foreach (var p in messages)
+            {
+                try
+                {
+                    await _recoveryInterceptor.InterceptAsync(p);
+                    recoveryCallback(p);
+                }
+                catch (TestJournalFailureException)
+                {
+                    // i.e. problems with data: corrupted data-set, problems in serialization
+                    // i.e. data-store problems: network, invalid credentials, etc.
+                    throw;
+                }
+            }
+        }
+    }
+
+    public override async Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+    {
+        await _connectionInterceptor.InterceptAsync();
+        return await base.ReadHighestSequenceNrAsync(persistenceId, fromSequenceNr);
+    }
+
+    /// <summary>
+    ///     Create proxy object from journal actor reference which can alter behavior of journal.
+    /// </summary>
+    /// <remarks>
+    ///     Journal actor must be of <see cref="TestJournal"/> type.
+    /// </remarks>
+    /// <param name="actor">Journal actor reference.</param>
+    /// <returns>Proxy object to control <see cref="TestJournal"/>.</returns>
+    public static ITestJournal FromRef(IActorRef actor)
+    {
+        return new TestJournalWrapper(actor);
+    }
+
+    public sealed class UseWriteInterceptor
+    {
+        public UseWriteInterceptor(IJournalInterceptor interceptor)
+        {
+            Interceptor = interceptor;
+        }
+
+        public IJournalInterceptor Interceptor { get; }
+    }
+
+    public sealed class UseRecoveryInterceptor
+    {
+        public UseRecoveryInterceptor(IJournalInterceptor interceptor)
+        {
+            Interceptor = interceptor;
+        }
+
+        public IJournalInterceptor Interceptor { get; }
+    }
+
+    public sealed class UseConnectionInterceptor
+    {
+        public UseConnectionInterceptor(IConnectionInterceptor interceptor)
+        {
+            Interceptor = interceptor;
+        }
+
+        public IConnectionInterceptor Interceptor { get; }
+    }
+    
+    public sealed class Ack
+    {
+        public static readonly Ack Instance = new();
+    }
+
+    internal class TestJournalWrapper : ITestJournal
+    {
+        public TestJournalWrapper(IActorRef actor)
+        {
+            _actor = actor;
+        }
+
+        private readonly IActorRef _actor;
+
+        public JournalWriteBehavior OnWrite => new(new JournalWriteBehaviorSetter(_actor));
+
+        public JournalRecoveryBehavior OnRecovery => new(new JournalRecoveryBehaviorSetter(_actor));
+            
+        public JournalConnectionBehavior OnConnect => new(new JournalConnectionBehaviorSetter(_actor));
+    }
+}

--- a/Akka.HealthCheck.Persistence.TestKit/Journal/TestJournalFailureException.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/Journal/TestJournalFailureException.cs
@@ -1,0 +1,20 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TestJournalFailureException.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Akka.HealthCheck.Persistence.TestKit.Journal;
+
+[Serializable]
+public class TestJournalFailureException : Exception
+{
+    public TestJournalFailureException() { }
+    public TestJournalFailureException(string message) : base(message) { }
+    public TestJournalFailureException(string message, Exception inner) : base(message, inner) { }
+    protected TestJournalFailureException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+}

--- a/Akka.HealthCheck.Persistence.TestKit/Journal/TestJournalRejectionException.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/Journal/TestJournalRejectionException.cs
@@ -1,0 +1,20 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TestJournalRejectionException.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Akka.HealthCheck.Persistence.TestKit.Journal;
+
+[Serializable]
+public class TestJournalRejectionException : Exception
+{
+    public TestJournalRejectionException() { }
+    public TestJournalRejectionException(string message) : base(message) { }
+    public TestJournalRejectionException(string message, Exception inner) : base(message, inner) { }
+    protected TestJournalRejectionException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+}

--- a/Akka.HealthCheck.Persistence.TestKit/PersistenceTestKit.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/PersistenceTestKit.cs
@@ -1,0 +1,382 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="PersistenceTestKit.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Actor.Setup;
+using Akka.Configuration;
+using Akka.HealthCheck.Persistence.TestKit.Journal;
+using Akka.HealthCheck.Persistence.TestKit.SnapshotStore;
+using Xunit.Abstractions;
+
+namespace Akka.HealthCheck.Persistence.TestKit;
+
+/// <summary>
+/// This class represents an Akka.NET Persistence TestKit that uses <a href="https://xunit.github.io/">xUnit</a>
+/// as its testing framework.
+/// </summary>
+public abstract class PersistenceTestKit : Akka.TestKit.Xunit2.TestKit
+{
+    /// <summary>
+    /// Create a new instance of the <see cref="PersistenceTestKit"/> class.
+    /// A new system with the specified configuration will be created.
+    /// </summary>
+    /// <param name="setup">Test ActorSystem configuration</param>
+    /// <param name="actorSystemName">Optional: The name of the actor system</param>
+    /// <param name="output">TBD</param>
+    protected PersistenceTestKit(ActorSystemSetup setup, string actorSystemName = null, ITestOutputHelper output = null)
+        : base(GetConfig(setup), actorSystemName, output)
+    {
+        var persistenceExtension = Akka.Persistence.Persistence.Instance.Apply(Sys);
+
+        JournalActorRef = persistenceExtension.JournalFor(null);
+        Journal = TestJournal.FromRef(JournalActorRef);
+
+        SnapshotsActorRef = persistenceExtension.SnapshotStoreFor(null);
+        Snapshots = TestSnapshotStore.FromRef(SnapshotsActorRef);
+    }
+
+    /// <summary>
+    /// Create a new instance of the <see cref="PersistenceTestKit"/> class.
+    /// A new system with the specified configuration will be created.
+    /// </summary>
+    /// <param name="config">Test ActorSystem configuration</param>
+    /// <param name="actorSystemName">Optional: The name of the actor system</param>
+    /// <param name="output">TBD</param>
+    protected PersistenceTestKit(Config config, string actorSystemName = null, ITestOutputHelper output = null)
+        : base(GetConfig(config), actorSystemName, output)
+    {
+        var persistenceExtension = Akka.Persistence.Persistence.Instance.Apply(Sys);
+
+        JournalActorRef = persistenceExtension.JournalFor(null);
+        Journal = TestJournal.FromRef(JournalActorRef);
+
+        SnapshotsActorRef = persistenceExtension.SnapshotStoreFor(null);
+        Snapshots = TestSnapshotStore.FromRef(SnapshotsActorRef);
+    }
+
+    /// <summary>
+    /// Create a new instance of the <see cref="PersistenceTestKit"/> class.
+    /// A new system with the default configuration will be created.
+    /// </summary>
+    /// <param name="actorSystemName">Optional: The name of the actor system</param>
+    /// <param name="output">TBD</param>
+    protected PersistenceTestKit(string actorSystemName = null, ITestOutputHelper output = null)
+        : this(Config.Empty, actorSystemName, output)
+    {
+    }
+
+    /// <summary>
+    /// Actor reference to persistence Journal used by current actor system.
+    /// </summary>
+    public IActorRef JournalActorRef { get; }
+
+    /// <summary>
+    /// Actor reference to persistence Snapshot Store used by current actor system.
+    /// </summary>
+    public IActorRef SnapshotsActorRef { get; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public ITestJournal Journal { get; } 
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public ITestSnapshotStore Snapshots { get; } 
+
+    public async Task WithJournalConnection(Func<JournalConnectionBehavior, Task> behaviorSelector, Func<Task> execution)
+    {
+        try
+        {
+            await behaviorSelector(Journal.OnConnect);
+            await execution();
+        }
+        finally
+        {
+            await Journal.OnConnect.Pass();
+        }
+    }
+    
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Recovery operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Recovery behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public async Task WithJournalRecovery(Func<JournalRecoveryBehavior, Task> behaviorSelector, Func<Task> execution)
+    {
+        if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+        if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+        try
+        {
+            await behaviorSelector(Journal.OnRecovery);
+            await execution();
+        }
+        finally
+        {
+            await Journal.OnRecovery.Pass();
+        }
+    }
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Write operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Write behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public async Task WithJournalWrite(Func<JournalWriteBehavior, Task> behaviorSelector, Func<Task> execution)
+    {
+        if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+        if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+        try
+        {
+            await behaviorSelector(Journal.OnWrite);
+            await execution();
+        }
+        finally
+        {
+            await Journal.OnWrite.Pass();
+        }
+    }
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Recovery operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Recovery behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
+    /// <param name="execution">Delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public Task WithJournalRecovery(Func<JournalRecoveryBehavior, Task> behaviorSelector, Action execution)
+        => WithJournalRecovery(behaviorSelector, () =>
+        {
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            execution();
+            return Task.FromResult(new object());
+        });
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Write operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Write behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
+    /// <param name="execution">Delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public Task WithJournalWrite(Func<JournalWriteBehavior, Task> behaviorSelector, Action execution)
+        => WithJournalWrite(behaviorSelector, () =>
+        {
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            execution();
+            return Task.FromResult(new object());
+        });
+
+    public async Task WithSnapshotConnection(Func<SnapshotStoreConnectionBehavior, Task> behaviorSelector, Func<Task> execution)
+    {
+        if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+        if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+        try
+        {
+            await behaviorSelector(Snapshots.OnConnect);
+            await execution();
+        }
+        finally
+        {
+            await Snapshots.OnConnect.Pass();
+        }
+    }
+
+    
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Save operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Save behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public async Task WithSnapshotSave(Func<SnapshotStoreSaveBehavior, Task> behaviorSelector, Func<Task> execution)
+    {
+        if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+        if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+        try
+        {
+            await behaviorSelector(Snapshots.OnSave);
+            await execution();
+        }
+        finally
+        {
+            await Snapshots.OnSave.Pass();
+        }
+    }
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Load operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Load behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public async Task WithSnapshotLoad(Func<SnapshotStoreLoadBehavior, Task> behaviorSelector, Func<Task> execution)
+    {
+        if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+        if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+        try
+        {
+            await behaviorSelector(Snapshots.OnLoad);
+            await execution();
+        }
+        finally
+        {
+            await Snapshots.OnLoad.Pass();
+        }
+    }
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Delete operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Delete behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public async Task WithSnapshotDelete(Func<SnapshotStoreDeleteBehavior, Task> behaviorSelector, Func<Task> execution)
+    {
+        if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+        if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+        try
+        {
+            await behaviorSelector(Snapshots.OnDelete);
+            await execution();
+        }
+        finally
+        {
+            await Snapshots.OnDelete.Pass();
+        }
+    }
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Save operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Save behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+    /// <param name="execution">Delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public Task WithSnapshotSave(Func<SnapshotStoreSaveBehavior, Task> behaviorSelector, Action execution)
+        => WithSnapshotSave(behaviorSelector, () =>
+        {
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            execution();
+            return Task.FromResult(true);
+        });
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Load operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Load behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public Task WithSnapshotLoad(Func<SnapshotStoreLoadBehavior, Task> behaviorSelector, Action execution)
+        => WithSnapshotLoad(behaviorSelector, () =>
+        {
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            execution();
+            return Task.FromResult(true);
+        });
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Delete operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Delete behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public Task WithSnapshotDelete(Func<SnapshotStoreDeleteBehavior, Task> behaviorSelector, Action execution)
+        => WithSnapshotDelete(behaviorSelector, () =>
+        {
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            execution();
+            return Task.FromResult(true);
+        });
+
+    /// <summary>
+    ///     Loads from embedded resources actor system persistence configuration with <see cref="TestJournal"/> and
+    ///     <see cref="TestSnapshotStore"/> configured as default persistence plugins.
+    /// </summary>
+    /// <param name="customConfig">Custom configuration that was passed in the constructor.</param>
+    /// <returns>Actor system configuration object.</returns>
+    /// <seealso cref="Config"/>
+    private static ActorSystemSetup GetConfig(ActorSystemSetup customConfig)
+    {
+        var bootstrapSetup = customConfig.Get<BootstrapSetup>();
+        var config = bootstrapSetup.FlatSelect(x => x.Config);
+        var actorProvider = bootstrapSetup.FlatSelect(x => x.ActorRefProvider);
+        var newSetup = BootstrapSetup.Create();
+        if (config.HasValue)
+        {
+            newSetup = newSetup.WithConfig(GetConfig(config.Value));
+        }
+        else
+        {
+            newSetup = newSetup.WithConfig(GetConfig(Config.Empty));
+        }
+
+        if (actorProvider.HasValue)
+        {
+            newSetup = newSetup.WithActorRefProvider(actorProvider.Value);
+        }
+
+        return customConfig.WithSetup(newSetup);
+    }
+
+    /// <summary>
+    ///     Loads from embedded resources actor system persistence configuration with <see cref="TestJournal"/> and
+    ///     <see cref="TestSnapshotStore"/> configured as default persistence plugins.
+    /// </summary>
+    /// <param name="customConfig">Custom configuration that was passed in the constructor.</param>
+    /// <returns>Actor system configuration object.</returns>
+    /// <seealso cref="Config"/>
+    private static Config GetConfig(Config customConfig)
+    {
+        var defaultConfig = ConfigurationFactory.FromResource<TestJournal>("Akka.HealthCheck.Persistence.TestKit.config.conf");
+        if (customConfig == Config.Empty) return defaultConfig;
+        else return defaultConfig.SafeWithFallback(customConfig);
+    }        
+}

--- a/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/ISnapshotStoreBehaviorSetter.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/ISnapshotStoreBehaviorSetter.cs
@@ -1,0 +1,15 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ISnapshotStoreBehaviorSetter.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+
+namespace Akka.HealthCheck.Persistence.TestKit.SnapshotStore;
+
+public interface ISnapshotStoreBehaviorSetter
+{
+    Task SetInterceptorAsync(ISnapshotStoreInterceptor interceptor);
+}

--- a/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/ISnapshotStoreConnectionBehaviorSetter.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/ISnapshotStoreConnectionBehaviorSetter.cs
@@ -1,0 +1,14 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="IConnectionBehaviorSetter.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+
+namespace Akka.HealthCheck.Persistence.TestKit.SnapshotStore;
+
+public interface ISnapshotStoreConnectionBehaviorSetter
+{
+    Task SetInterceptorAsync(IConnectionInterceptor interceptor);
+}

--- a/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/ISnapshotStoreInterceptor.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/ISnapshotStoreInterceptor.cs
@@ -1,0 +1,22 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ISnapshotStoreInterceptor.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Akka.Persistence;
+
+namespace Akka.HealthCheck.Persistence.TestKit.SnapshotStore;
+
+/// <summary>
+///     Interface to object which will intercept all action in <see cref="TestSnapshotStore"/>.
+/// </summary>
+public interface ISnapshotStoreInterceptor
+{
+    /// <summary>
+    ///     Method will be called for each load, save or delete attempt in <see cref="TestSnapshotStore"/>.
+    /// </summary>
+    Task InterceptAsync(string persistenceId, SnapshotSelectionCriteria criteria);
+}

--- a/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/ITestSnapshotStore.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/ITestSnapshotStore.cs
@@ -1,0 +1,16 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ITestSnapshotStore.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Akka.HealthCheck.Persistence.TestKit.SnapshotStore;
+
+public interface ITestSnapshotStore
+{
+    SnapshotStoreSaveBehavior OnSave { get; }
+    SnapshotStoreLoadBehavior OnLoad { get; }
+    SnapshotStoreDeleteBehavior OnDelete { get; }
+    SnapshotStoreConnectionBehavior OnConnect { get; }
+}

--- a/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/SnapshotStoreConnectionBehavior.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/SnapshotStoreConnectionBehavior.cs
@@ -1,0 +1,309 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SnapshotStoreRecoveryBehavior.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Persistence;
+
+namespace Akka.HealthCheck.Persistence.TestKit.SnapshotStore;
+
+/// <summary>
+///     Built-in SnapshotStore interceptors who will alter messages Recovery and/or Write of <see cref="TestSnapshotStore"/>.
+/// </summary>
+public class SnapshotStoreConnectionBehavior
+{
+    internal SnapshotStoreConnectionBehavior(ISnapshotStoreConnectionBehaviorSetter setter)
+    {
+        Setter = setter;
+    }
+
+    private ISnapshotStoreConnectionBehaviorSetter Setter { get; }
+
+    /// <summary>
+    ///     Use custom, user defined interceptor.
+    /// </summary>
+    /// <param name="interceptor">User defined interceptor which implements <see cref="ISnapshotStoreInterceptor"/> interface.</param>
+    /// <exception cref="ArgumentNullException">When <paramref name="interceptor"/> is <c>null</c>.</exception>
+    public Task SetInterceptorAsync(IConnectionInterceptor interceptor)
+    {
+        if (interceptor == null) throw new ArgumentNullException(nameof(interceptor));
+
+        return Setter.SetInterceptorAsync(interceptor);
+    }
+
+    /// <summary>
+    ///     Pass all messages to journal without interfering.
+    /// </summary>
+    /// <remarks>
+    ///     By using this interceptor <see cref="TestSnapshotStore"/> all journal operations will work like
+    ///     in standard <see cref="Akka.Persistence.SnapshotStore.MemorySnapshotStore"/>.
+    /// </remarks>
+    public Task Pass() => SetInterceptorAsync(ConnectionInterceptors.Noop.Instance);
+
+    /// <summary>
+    ///     Delay passing all messages to journal by <paramref name="delay"/>.
+    /// </summary>
+    /// <remarks>
+    ///     Each message will be delayed individually.
+    /// </remarks>
+    /// <param name="delay">Time by which recovery operation will be delayed.</param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    public Task PassWithDelay(TimeSpan delay)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+
+        return SetInterceptorAsync(new ConnectionInterceptors.Delay(delay, ConnectionInterceptors.Noop.Instance));
+    }
+
+    /// <summary>
+    ///     Always fail all messages.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         SnapshotStore will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this SnapshotStore behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    public Task Fail() => SetInterceptorAsync(ConnectionInterceptors.Failure.Instance);
+
+    /// <summary>
+    ///     Fail message if predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         SnapshotStore will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this SnapshotStore behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailIf(Func<bool> predicate)
+    {
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new ConnectionInterceptors.OnCondition(predicate, ConnectionInterceptors.Failure.Instance));
+    }
+
+    /// <summary>
+    ///     Fail message if async predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         SnapshotStore will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this SnapshotStore behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailIf(Func<Task<bool>> predicate)
+    {
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new ConnectionInterceptors.OnCondition(predicate, ConnectionInterceptors.Failure.Instance));
+    }
+
+    /// <summary>
+    ///     Fail message unless predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         SnapshotStore will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this SnapshotStore behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailUnless(Func<bool> predicate)
+    {
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new ConnectionInterceptors.OnCondition(predicate, ConnectionInterceptors.Failure.Instance, negate: true));
+    }
+
+    /// <summary>
+    ///     Fail message unless async predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         SnapshotStore will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this SnapshotStore behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailUnless(Func<Task<bool>> predicate)
+    {
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new ConnectionInterceptors.OnCondition(predicate, ConnectionInterceptors.Failure.Instance, negate: true));
+    }
+
+    /// <summary>
+    ///     Fail message after specified delay.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         SnapshotStore will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this SnapshotStore behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    public Task FailWithDelay(TimeSpan delay)
+    {
+        if (delay <= TimeSpan.Zero)  throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+
+        return SetInterceptorAsync(new ConnectionInterceptors.Delay(delay, ConnectionInterceptors.Failure.Instance));
+    }
+
+    /// <summary>
+    ///     Fail message after specified delay if async predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         SnapshotStore will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this SnapshotStore behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailIfWithDelay(TimeSpan delay, Func<Task<bool>> predicate)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new ConnectionInterceptors.OnCondition(
+            predicate, 
+            new ConnectionInterceptors.Delay(delay, ConnectionInterceptors.Failure.Instance)
+        ));
+    }
+
+    /// <summary>
+    ///     Fail message after specified delay if predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         SnapshotStore will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this SnapshotStore behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailIfWithDelay(TimeSpan delay, Func<bool> predicate)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new ConnectionInterceptors.OnCondition(
+            predicate, 
+            new ConnectionInterceptors.Delay(delay, ConnectionInterceptors.Failure.Instance)
+        ));
+    }
+
+    /// <summary>
+    ///     Fail message after specified delay unless predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         SnapshotStore will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this SnapshotStore behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailUnlessWithDelay(TimeSpan delay, Func<bool> predicate)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new ConnectionInterceptors.OnCondition(
+            predicate, 
+            new ConnectionInterceptors.Delay(delay, ConnectionInterceptors.Failure.Instance),
+            negate: true
+        ));
+    }
+
+    /// <summary>
+    ///     Fail message after specified delay unless async predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each message will be delayed individually.
+    ///     </para>
+    ///     <para>
+    ///         SnapshotStore will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
+    ///     </para>
+    ///     <para>
+    ///         Use this SnapshotStore behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying journal.
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailUnlessWithDelay(TimeSpan delay, Func<Task<bool>> predicate)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            
+        return SetInterceptorAsync(new ConnectionInterceptors.OnCondition(
+            predicate, 
+            new ConnectionInterceptors.Delay(delay, ConnectionInterceptors.Failure.Instance),
+            negate: true
+        ));
+    }
+}

--- a/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/SnapshotStoreConnectionBehaviorSetter.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/SnapshotStoreConnectionBehaviorSetter.cs
@@ -1,0 +1,31 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SnapshotStoreRecoveryBehaviorSetter.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+
+namespace Akka.HealthCheck.Persistence.TestKit.SnapshotStore;
+
+/// <summary>
+/// Setter strategy for TestSnapshotStore which will set recovery interceptor.
+/// </summary>
+internal class SnapshotStoreConnectionBehaviorSetter : ISnapshotStoreConnectionBehaviorSetter
+{
+    internal SnapshotStoreConnectionBehaviorSetter(IActorRef journal)
+    {
+        _journal = journal;
+    }
+
+    private readonly IActorRef _journal;
+
+    public Task SetInterceptorAsync(IConnectionInterceptor interceptor)
+        => _journal.Ask<TestSnapshotStore.Ack>(
+            new TestSnapshotStore.UseConnectionInterceptor(interceptor),
+            TimeSpan.FromSeconds(3)
+        );
+}

--- a/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/SnapshotStoreDeleteBehavior.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/SnapshotStoreDeleteBehavior.cs
@@ -1,0 +1,16 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SnapshotStoreDeleteBehavior.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Akka.HealthCheck.Persistence.TestKit.SnapshotStore;
+
+public class SnapshotStoreDeleteBehavior : SnapshotStoreSaveBehavior
+{
+    public SnapshotStoreDeleteBehavior(ISnapshotStoreBehaviorSetter setter) : base(setter)
+    {
+
+    }
+}

--- a/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/SnapshotStoreDeleteBehaviorSetter.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/SnapshotStoreDeleteBehaviorSetter.cs
@@ -1,0 +1,31 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SnapshotStoreDeleteBehaviorSetter.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+
+namespace Akka.HealthCheck.Persistence.TestKit.SnapshotStore;
+
+/// <summary>
+///     Setter strategy for <see cref="TestSnapshotStore"/> which will set delete interceptor.
+/// </summary>
+internal class SnapshotStoreDeleteBehaviorSetter : ISnapshotStoreBehaviorSetter
+{
+    internal SnapshotStoreDeleteBehaviorSetter(IActorRef snapshots)
+    {
+        this._snapshots = snapshots;
+    }
+
+    private readonly IActorRef _snapshots;
+
+    public Task SetInterceptorAsync(ISnapshotStoreInterceptor interceptor)
+        => _snapshots.Ask<TestSnapshotStore.Ack>(
+            new TestSnapshotStore.UseDeleteInterceptor(interceptor),
+            TimeSpan.FromSeconds(3)
+        );
+}

--- a/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/SnapshotStoreInterceptors.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/SnapshotStoreInterceptors.cs
@@ -1,0 +1,158 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SnapshotStoreInterceptors.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Persistence;
+
+namespace Akka.HealthCheck.Persistence.TestKit.SnapshotStore;
+
+public static class SnapshotStoreInterceptors
+{
+    public class Noop : ISnapshotStoreInterceptor
+    {
+        public static readonly ISnapshotStoreInterceptor Instance = new Noop();
+
+        public Task InterceptAsync(string persistenceId, SnapshotSelectionCriteria criteria) => Task.FromResult(true);
+    }
+
+    public class Failure : ISnapshotStoreInterceptor
+    {
+        public static readonly ISnapshotStoreInterceptor Instance = new Failure();
+
+        public Task InterceptAsync(string persistenceId, SnapshotSelectionCriteria criteria) => throw new TestSnapshotStoreFailureException(); 
+    }
+
+    public class MultiFailure : ISnapshotStoreInterceptor
+    {
+        public MultiFailure(int times, ISnapshotStoreInterceptor? next = null)
+        {
+            _times = times;
+            _next = next ?? Noop.Instance;
+        }
+
+        private readonly int _times;
+        private readonly ISnapshotStoreInterceptor _next;
+        private int _count;
+        
+        public Task InterceptAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        {
+            if (_count >= _times)
+            {
+                _next.InterceptAsync(persistenceId, criteria);
+                return Task.CompletedTask;
+            }
+
+            _count++;
+            throw new TestSnapshotStoreFailureException($"Failing snapshot {_count}/{_times}");
+        }
+    }
+    
+    public class Delay : ISnapshotStoreInterceptor
+    {
+        public Delay(TimeSpan delay, ISnapshotStoreInterceptor next)
+        {
+            _delay = delay;
+            _next = next;
+        }
+
+        private readonly TimeSpan _delay;
+        private readonly ISnapshotStoreInterceptor _next;
+
+        public async Task InterceptAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        {
+            await Task.Delay(_delay);
+            await _next.InterceptAsync(persistenceId, criteria);
+        }
+    }
+    
+    public class DelayOnce: ISnapshotStoreInterceptor
+    {
+        public DelayOnce(TimeSpan delay, ISnapshotStoreInterceptor next)
+        {
+            _delay = delay;
+            _next = next;
+        }
+
+        private readonly TimeSpan _delay;
+        private readonly ISnapshotStoreInterceptor _next;
+        private bool _delayed;
+
+        public async Task InterceptAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        {
+            if (!_delayed)
+            {
+                _delayed = true;
+                await Task.Delay(_delay);
+            }
+            await _next.InterceptAsync(persistenceId, criteria);
+        }
+    }
+
+    public sealed class OnCondition : ISnapshotStoreInterceptor
+    {
+        public OnCondition(Func<string, SnapshotSelectionCriteria, Task<bool>> predicate, ISnapshotStoreInterceptor next, bool negate = false)
+        {
+            _predicate = predicate;
+            _next = next;
+            _negate = negate;
+        }
+
+        public OnCondition(Func<string, SnapshotSelectionCriteria, bool> predicate, ISnapshotStoreInterceptor next, bool negate = false)
+        {
+            _predicate = (persistenceId, criteria) => Task.FromResult(predicate(persistenceId, criteria));
+            _next = next;
+            _negate = negate;
+        }
+
+        private readonly Func<string, SnapshotSelectionCriteria, Task<bool>> _predicate;
+        private readonly ISnapshotStoreInterceptor _next;
+        private readonly bool _negate;
+
+        public async Task InterceptAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        {
+            var result = await _predicate(persistenceId, criteria);
+            if ((_negate && !result) || (!_negate && result))
+            {
+                await _next.InterceptAsync(persistenceId, criteria);
+            }
+        }
+    }
+    
+    public class CancelableDelay: ISnapshotStoreInterceptor
+    {
+        public CancelableDelay(TimeSpan delay, ISnapshotStoreInterceptor next, CancellationToken cancellationToken)
+        {
+            _delay = delay;
+            _next = next;
+            _cancellationToken = cancellationToken;
+        }
+
+        private readonly TimeSpan _delay;
+        private readonly ISnapshotStoreInterceptor _next;
+        private readonly CancellationToken _cancellationToken;
+
+        public async Task InterceptAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        {
+            try
+            {
+                await Task.Delay(_delay, _cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // no-op
+            }
+            catch (TimeoutException)
+            {
+                // no-op
+            }
+            await _next.InterceptAsync(persistenceId, criteria);
+        }
+    }
+
+}

--- a/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/SnapshotStoreLoadBehavior.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/SnapshotStoreLoadBehavior.cs
@@ -1,0 +1,16 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SnapshotStoreLoadBehavior.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Akka.HealthCheck.Persistence.TestKit.SnapshotStore;
+
+public class SnapshotStoreLoadBehavior : SnapshotStoreSaveBehavior
+{
+    public SnapshotStoreLoadBehavior(ISnapshotStoreBehaviorSetter setter) : base(setter)
+    {
+
+    }
+}

--- a/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/SnapshotStoreLoadBehaviorSetter.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/SnapshotStoreLoadBehaviorSetter.cs
@@ -1,0 +1,31 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SnapshotStoreLoadBehaviorSetter.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+
+namespace Akka.HealthCheck.Persistence.TestKit.SnapshotStore;
+
+/// <summary>
+///     Setter strategy for <see cref="TestSnapshotStore"/> which will set load interceptor.
+/// </summary>
+internal class SnapshotStoreLoadBehaviorSetter : ISnapshotStoreBehaviorSetter
+{
+    internal SnapshotStoreLoadBehaviorSetter(IActorRef snapshots)
+    {
+        this._snapshots = snapshots;
+    }
+
+    private readonly IActorRef _snapshots;
+
+    public Task SetInterceptorAsync(ISnapshotStoreInterceptor interceptor)
+        => _snapshots.Ask<TestSnapshotStore.Ack>(
+            new TestSnapshotStore.UseLoadInterceptor(interceptor),
+            TimeSpan.FromSeconds(3)
+        );
+}

--- a/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/SnapshotStoreSaveBehavior.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/SnapshotStoreSaveBehavior.cs
@@ -1,0 +1,302 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SnapshotStoreSaveBehavior.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Persistence;
+
+namespace Akka.HealthCheck.Persistence.TestKit.SnapshotStore;
+
+using InterceptorPredicate = System.Func<string, SnapshotSelectionCriteria, bool>;
+using AsyncInterceptorPredicate = System.Func<string, SnapshotSelectionCriteria, System.Threading.Tasks.Task<bool>>;
+
+/// <summary>
+///     Built-in snapshot store interceptors who will alter message Write of <see cref="TestSnapshotStore"/>.
+/// </summary>
+public class SnapshotStoreSaveBehavior
+{
+    public SnapshotStoreSaveBehavior(ISnapshotStoreBehaviorSetter setter)
+    {
+        Setter = setter;
+    }
+
+    protected readonly ISnapshotStoreBehaviorSetter Setter;
+
+    /// <summary>
+    ///     Use custom, user defined interceptor.
+    /// </summary>
+    /// <param name="interceptor">User defined interceptor which implements <see cref="ISnapshotStoreInterceptor"/> interface.</param>
+    /// <exception cref="ArgumentNullException">When <paramref name="interceptor"/> is <c>null</c>.</exception>
+    public Task SetInterceptorAsync(ISnapshotStoreInterceptor interceptor)
+    {
+        if (interceptor == null) throw new ArgumentNullException(nameof(interceptor));
+
+        return Setter.SetInterceptorAsync(interceptor);
+    }
+
+    /// <summary>
+    ///     Pass all messages to snapshot store without interfering.
+    /// </summary>
+    /// <remarks>
+    ///     By using this interceptor <see cref="TestSnapshotStore"/> all snapshot store operations will work like
+    ///     in standard <see cref="Akka.Persistence.Snapshot.MemorySnapshotStore"/>.
+    /// </remarks>
+    public Task Pass() => SetInterceptorAsync(SnapshotStoreInterceptors.Noop.Instance);
+
+    /// <summary>
+    ///     Delay passing all messages to snapshot store by <paramref name="delay"/>.
+    /// </summary>
+    /// <remarks>
+    ///     Each message will be delayed individually.
+    /// </remarks>
+    /// <param name="delay">Time by which recovery operation will be delayed.</param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    public Task PassWithDelay(TimeSpan delay)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+
+        return SetInterceptorAsync(new SnapshotStoreInterceptors.Delay(delay, SnapshotStoreInterceptors.Noop.Instance));
+    }
+
+    /// <summary>
+    ///     Always fail all messages.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Snapshot store will crash and actor will receive one of <see cref="SaveSnapshotFailure"/>,
+    ///         <see cref="DeleteSnapshotFailure"/> or <see cref="DeleteSnapshotsFailure"/> messages.
+    ///     </para>
+    ///     <para>
+    ///         Use this snapshot store behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying snapshot store.
+    ///     </para>
+    /// </remarks>
+    public Task Fail() => SetInterceptorAsync(SnapshotStoreInterceptors.Failure.Instance);
+
+    /// <summary>
+    ///     Fail message if predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Snapshot store will crash and actor will receive one of <see cref="SaveSnapshotFailure"/>,
+    ///         <see cref="DeleteSnapshotFailure"/> or <see cref="DeleteSnapshotsFailure"/> messages.
+    ///     </para>
+    ///     <para>
+    ///         Use this snapshot store behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying snapshot store.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailIf(InterceptorPredicate predicate)
+    {
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new SnapshotStoreInterceptors.OnCondition(predicate, SnapshotStoreInterceptors.Failure.Instance));
+    }
+
+    /// <summary>
+    ///     Fail message if async predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Snapshot store will crash and actor will receive one of <see cref="SaveSnapshotFailure"/>,
+    ///         <see cref="DeleteSnapshotFailure"/> or <see cref="DeleteSnapshotsFailure"/> messages.
+    ///     </para>
+    ///     <para>
+    ///         Use this snapshot store behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying snapshot store.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailIf(AsyncInterceptorPredicate predicate)
+    {
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new SnapshotStoreInterceptors.OnCondition(predicate, SnapshotStoreInterceptors.Failure.Instance));
+    }
+
+    /// <summary>
+    ///     Fail message unless predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Snapshot store will crash and actor will receive one of <see cref="SaveSnapshotFailure"/>,
+    ///         <see cref="DeleteSnapshotFailure"/> or <see cref="DeleteSnapshotsFailure"/> messages.
+    ///     </para>
+    ///     <para>
+    ///         Use this snapshot store behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying snapshot store.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailUnless(InterceptorPredicate predicate)
+    {
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new SnapshotStoreInterceptors.OnCondition(predicate, SnapshotStoreInterceptors.Failure.Instance, negate: true));
+    }
+
+    /// <summary>
+    ///     Fail message unless async predicate <paramref name="predicate"/> will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Snapshot store will crash and actor will receive one of <see cref="SaveSnapshotFailure"/>,
+    ///         <see cref="DeleteSnapshotFailure"/> or <see cref="DeleteSnapshotsFailure"/> messages.
+    ///     </para>
+    ///     <para>
+    ///         Use this snapshot store behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///         and similar issues with underlying snapshot store.
+    ///     </para>
+    /// </remarks>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailUnless(AsyncInterceptorPredicate predicate)
+    {
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new SnapshotStoreInterceptors.OnCondition(predicate, SnapshotStoreInterceptors.Failure.Instance, negate: true));
+    }
+
+    /// <summary>
+    ///     Fail message after specified delay.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Snapshot store will crash and actor will receive one of <see cref="SaveSnapshotFailure"/>,
+    ///         <see cref="DeleteSnapshotFailure"/> or <see cref="DeleteSnapshotsFailure"/> messages.
+    ///     </para>
+    ///     <para>
+    ///         Use this snapshot store behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    public Task FailWithDelay(TimeSpan delay)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+
+        return SetInterceptorAsync(new SnapshotStoreInterceptors.Delay(delay, SnapshotStoreInterceptors.Failure.Instance));
+    }
+
+    /// <summary>
+    ///     Fail message after specified delay if async predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Snapshot store will crash and actor will receive one of <see cref="SaveSnapshotFailure"/>,
+    ///         <see cref="DeleteSnapshotFailure"/> or <see cref="DeleteSnapshotsFailure"/> messages.
+    ///     </para>
+    ///     <para>
+    ///         Use this snapshot store behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailIfWithDelay(TimeSpan delay, AsyncInterceptorPredicate predicate)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new SnapshotStoreInterceptors.OnCondition(
+            predicate, 
+            new SnapshotStoreInterceptors.Delay(delay, SnapshotStoreInterceptors.Failure.Instance)
+        ));
+    }
+
+    /// <summary>
+    ///     Fail message after specified delay if predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Snapshot store will crash and actor will receive one of <see cref="SaveSnapshotFailure"/>,
+    ///         <see cref="DeleteSnapshotFailure"/> or <see cref="DeleteSnapshotsFailure"/> messages.
+    ///     </para>
+    ///     <para>
+    ///         Use this snapshot store behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailIfWithDelay(TimeSpan delay, InterceptorPredicate predicate)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new SnapshotStoreInterceptors.OnCondition(
+            predicate, 
+            new SnapshotStoreInterceptors.Delay(delay, SnapshotStoreInterceptors.Failure.Instance)
+        ));
+    }
+
+    /// <summary>
+    ///     Fail message after specified delay unless predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Snapshot store will crash and actor will receive one of <see cref="SaveSnapshotFailure"/>,
+    ///         <see cref="DeleteSnapshotFailure"/> or <see cref="DeleteSnapshotsFailure"/> messages.
+    ///     </para>
+    ///     <para>
+    ///         Use this snapshot store behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailUnlessWithDelay(TimeSpan delay, InterceptorPredicate predicate)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return SetInterceptorAsync(new SnapshotStoreInterceptors.OnCondition(
+            predicate, 
+            new SnapshotStoreInterceptors.Delay(delay, SnapshotStoreInterceptors.Failure.Instance),
+            negate: true
+        ));
+    }
+
+    /// <summary>
+    ///     Fail message after specified delay unless async predicate <paramref name="predicate"/>
+    ///     will return <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Snapshot store will crash and actor will receive one of <see cref="SaveSnapshotFailure"/>,
+    ///         <see cref="DeleteSnapshotFailure"/> or <see cref="DeleteSnapshotsFailure"/> messages.
+    ///     </para>
+    ///     <para>
+    ///         Use this snapshot store behavior when it is needed to verify how well a persistent actor will handle network problems
+    ///     </para>
+    /// </remarks>
+    /// <param name="delay"></param>
+    /// <param name="predicate"></param>
+    /// <exception cref="ArgumentException">When <paramref name="delay"/> is less or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is <c>null</c>.</exception>
+    public Task FailUnlessWithDelay(TimeSpan delay, AsyncInterceptorPredicate predicate)
+    {
+        if (delay <= TimeSpan.Zero) throw new ArgumentException("Delay must be greater than zero", nameof(delay));
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            
+        return SetInterceptorAsync(new SnapshotStoreInterceptors.OnCondition(
+            predicate, 
+            new SnapshotStoreInterceptors.Delay(delay, SnapshotStoreInterceptors.Failure.Instance),
+            negate: true
+        ));
+    }
+}

--- a/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/SnapshotStoreSaveBehaviorSetter.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/SnapshotStoreSaveBehaviorSetter.cs
@@ -1,0 +1,31 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SnapshotStoreSaveBehaviorSetter.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+
+namespace Akka.HealthCheck.Persistence.TestKit.SnapshotStore;
+
+/// <summary>
+///     Setter strategy for <see cref="TestSnapshotStore"/> which will set save interceptor.
+/// </summary>
+internal class SnapshotStoreSaveBehaviorSetter : ISnapshotStoreBehaviorSetter
+{
+    internal SnapshotStoreSaveBehaviorSetter(IActorRef snapshots)
+    {
+        this._snapshots = snapshots;
+    }
+
+    private readonly IActorRef _snapshots;
+
+    public Task SetInterceptorAsync(ISnapshotStoreInterceptor interceptor)
+        => _snapshots.Ask<TestSnapshotStore.Ack>(
+            new TestSnapshotStore.UseSaveInterceptor(interceptor),
+            TimeSpan.FromSeconds(3)
+        );
+}

--- a/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/TestSnapshotStore.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/TestSnapshotStore.cs
@@ -1,0 +1,157 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TestSnapshotStore.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Persistence;
+using Akka.Persistence.Snapshot;
+
+namespace Akka.HealthCheck.Persistence.TestKit.SnapshotStore;
+
+/// <summary>
+///     In-memory persistence snapshot store implementation which behavior could be controlled by interceptors.
+/// </summary>
+public class TestSnapshotStore : MemorySnapshotStore
+{
+    private ISnapshotStoreInterceptor _saveInterceptor = SnapshotStoreInterceptors.Noop.Instance;
+    private ISnapshotStoreInterceptor _loadInterceptor = SnapshotStoreInterceptors.Noop.Instance;
+    private ISnapshotStoreInterceptor _deleteInterceptor = SnapshotStoreInterceptors.Noop.Instance;
+    private IConnectionInterceptor _connectionInterceptor = ConnectionInterceptors.Noop.Instance;
+
+    protected override bool ReceivePluginInternal(object message)
+    {
+        switch (message)
+        {
+            case UseSaveInterceptor use:
+                _saveInterceptor = use.Interceptor;
+                Sender.Tell(Ack.Instance);
+                return true;
+
+            case UseLoadInterceptor use:
+                _loadInterceptor = use.Interceptor;
+                Sender.Tell(Ack.Instance);
+                return true;
+
+            case UseDeleteInterceptor use:
+                _deleteInterceptor = use.Interceptor;
+                Sender.Tell(Ack.Instance);
+                return true;
+
+            case UseConnectionInterceptor use:
+                _connectionInterceptor = use.Interceptor;
+                Sender.Tell(Ack.Instance);
+                return true;
+                
+            default:
+                return base.ReceivePluginInternal(message);
+        }
+    }
+
+    protected override async Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+    {
+        await _connectionInterceptor.InterceptAsync();
+        await _saveInterceptor.InterceptAsync(metadata.PersistenceId, ToSelectionCriteria(metadata));
+        await base.SaveAsync(metadata, snapshot);
+    }
+
+    protected override async Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+    {
+        await _connectionInterceptor.InterceptAsync();
+        await _loadInterceptor.InterceptAsync(persistenceId, criteria);
+        return await base.LoadAsync(persistenceId, criteria);
+    }
+
+    protected override async Task DeleteAsync(SnapshotMetadata metadata)
+    {
+        await _connectionInterceptor.InterceptAsync();
+        await _deleteInterceptor.InterceptAsync(metadata.PersistenceId, ToSelectionCriteria(metadata));
+        await base.DeleteAsync(metadata);
+    }
+
+    protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+    {
+        await _connectionInterceptor.InterceptAsync();
+        await _deleteInterceptor.InterceptAsync(persistenceId, criteria);
+        await base.DeleteAsync(persistenceId, criteria);
+    }
+
+    static SnapshotSelectionCriteria ToSelectionCriteria(SnapshotMetadata metadata)
+        => new(metadata.SequenceNr, metadata.Timestamp, metadata.SequenceNr, metadata.Timestamp);
+
+    /// <summary>
+    ///     Create proxy object from snapshot store actor reference which can alter behavior of snapshot store.
+    /// </summary>
+    /// <remarks>
+    ///     Snapshot store actor must be of <see cref="TestSnapshotStore"/> type.
+    /// </remarks>
+    /// <param name="actor">Journal actor reference.</param>
+    /// <returns>Proxy object to control <see cref="TestSnapshotStore"/>.</returns>
+    public static ITestSnapshotStore FromRef(IActorRef actor)
+    {
+        return new TestSnapshotStoreWrapper(actor);
+    }
+
+    public sealed class UseSaveInterceptor
+    {
+        public UseSaveInterceptor(ISnapshotStoreInterceptor interceptor)
+        {
+            Interceptor = interceptor;
+        }
+
+        public ISnapshotStoreInterceptor Interceptor { get; }
+    }
+
+    public sealed class UseLoadInterceptor
+    {
+        public UseLoadInterceptor(ISnapshotStoreInterceptor interceptor)
+        {
+            Interceptor = interceptor;
+        }
+
+        public ISnapshotStoreInterceptor Interceptor { get; }
+    }
+
+    public sealed class UseDeleteInterceptor
+    {
+        public UseDeleteInterceptor(ISnapshotStoreInterceptor interceptor)
+        {
+            Interceptor = interceptor;
+        }
+
+        public ISnapshotStoreInterceptor Interceptor { get; }
+    }
+
+    public sealed class UseConnectionInterceptor
+    {
+        public UseConnectionInterceptor(IConnectionInterceptor interceptor)
+        {
+            Interceptor = interceptor;
+        }
+
+        public IConnectionInterceptor Interceptor { get; }
+    }
+    
+    public sealed class Ack
+    {
+        public static readonly Ack Instance = new();
+    }
+
+    internal class TestSnapshotStoreWrapper : ITestSnapshotStore
+    {
+        public TestSnapshotStoreWrapper(IActorRef actor)
+        {
+            _actor = actor;
+        }
+
+        private readonly IActorRef _actor;
+
+        public SnapshotStoreSaveBehavior OnSave => new(new SnapshotStoreSaveBehaviorSetter(_actor));
+        public SnapshotStoreLoadBehavior OnLoad => new(new SnapshotStoreLoadBehaviorSetter(_actor));
+        public SnapshotStoreDeleteBehavior OnDelete => new(new SnapshotStoreDeleteBehaviorSetter(_actor));
+        public SnapshotStoreConnectionBehavior OnConnect => new(new SnapshotStoreConnectionBehaviorSetter(_actor));
+    }
+}

--- a/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/TestSnapshotStoreFailureException.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/SnapshotStore/TestSnapshotStoreFailureException.cs
@@ -1,0 +1,20 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TestSnapshotStoreFailureException.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Akka.HealthCheck.Persistence.TestKit.SnapshotStore;
+
+[Serializable]
+public class TestSnapshotStoreFailureException : Exception
+{
+    public TestSnapshotStoreFailureException() { }
+    public TestSnapshotStoreFailureException(string message) : base(message) { }
+    public TestSnapshotStoreFailureException(string message, Exception inner) : base(message, inner) { }
+    protected TestSnapshotStoreFailureException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+}

--- a/Akka.HealthCheck.Persistence.TestKit/TestConnectionException.cs
+++ b/Akka.HealthCheck.Persistence.TestKit/TestConnectionException.cs
@@ -1,0 +1,18 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="TestJournalConnectionException.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Akka.HealthCheck.Persistence.TestKit;
+
+public class TestConnectionException: Exception
+{
+    public TestConnectionException() { }
+    public TestConnectionException(string message) : base(message) { }
+    public TestConnectionException(string message, Exception inner) : base(message, inner) { }
+    protected TestConnectionException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+}

--- a/Akka.HealthCheck.Persistence.TestKit/config.conf
+++ b/Akka.HealthCheck.Persistence.TestKit/config.conf
@@ -1,0 +1,23 @@
+akka {
+  persistence {
+    journal {
+      plugin = "akka.persistence.journal.test"
+      auto-start-journals = ["akka.persistence.journal.test"]
+
+      test {
+        class = "Akka.HealthCheck.Persistence.TestKit.Journal.TestJournal, Akka.HealthCheck.Persistence.TestKit"
+        plugin-dispatcher = "akka.actor.default-dispatcher"
+      }
+    }
+
+    snapshot-store {
+      plugin = "akka.persistence.snapshot-store.test"
+      auto-start-snapshot-stores = ["akka.persistence.snapshot-store.test"]
+
+      test {
+        class = "Akka.HealthCheck.Persistence.TestKit.SnapshotStore.TestSnapshotStore, Akka.HealthCheck.Persistence.TestKit"
+        plugin-dispatcher = "akka.actor.default-dispatcher"        
+      }
+    }
+  }
+}

--- a/Akka.HealthCheck.sln
+++ b/Akka.HealthCheck.sln
@@ -52,6 +52,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		RELEASE_NOTES.md = RELEASE_NOTES.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.HealthCheck.Persistence.TestKit", "Akka.HealthCheck.Persistence.TestKit\Akka.HealthCheck.Persistence.TestKit.csproj", "{D2E7016C-3404-487D-B098-67A5A5C0390F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -110,6 +112,10 @@ Global
 		{8C123D9E-0AD1-4480-9EBE-9DC5D17D1575}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8C123D9E-0AD1-4480-9EBE-9DC5D17D1575}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8C123D9E-0AD1-4480-9EBE-9DC5D17D1575}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D2E7016C-3404-487D-B098-67A5A5C0390F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2E7016C-3404-487D-B098-67A5A5C0390F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D2E7016C-3404-487D-B098-67A5A5C0390F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D2E7016C-3404-487D-B098-67A5A5C0390F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adding Akka.HealthCheck.Persistence.TestKit. This is a copy of Akka.Persistence.Xunit2.TestKit with modifications so that it can be used to check persistence health.

All of the changes are additions only, no original code logic was changed, we might want to fold this back into Akka.Persistence.TestKit in the future.

Additions:
* Add connection failure interceptors.
  Akka.Persistence.TestKit applies interceptors per message, making it unsuitable to test conditions where the backing storage itself is failing.
* Make interceptor classes public instead of internal
  All of Akka.Persistence.TestKit interceptor classes are internal, making it impossible to compose your own interceptors
* Add a few new interceptors
  * `CancelableDelay` allows user to block a thread until it is canceled, so the test does not rely on strict timing and delays
  * `MultiFailure` allows user to specifically fail an operation X number of times
  * `DelayOnce` allows user to compose a delay intercept that can be followed immediately by an arbitrary interceptor