### PR TITLE
[Repro] New Akka.Hosting health check causes recursion bug

### DIFF
--- a/src/Akka.HealthCheck.Hosting.Web.Example/Akka.HealthCheck.Hosting.Web.Example.csproj
+++ b/src/Akka.HealthCheck.Hosting.Web.Example/Akka.HealthCheck.Hosting.Web.Example.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(NetTestVersion)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,5 +21,9 @@
     <EmbeddedResource Remove="snapshots\**" />
     <None Remove="snapshots\**" />
     <Content Remove="snapshots\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
   </ItemGroup>
 </Project>

--- a/src/Akka.HealthCheck.Hosting.Web.Example/Program.cs
+++ b/src/Akka.HealthCheck.Hosting.Web.Example/Program.cs
@@ -1,5 +1,8 @@
 using Akka.Cluster.Hosting;
 using Akka.Hosting;
+using Akka.Remote.Hosting;
+using Akka.Serialization;
+using LogLevel = Akka.Event.LogLevel;
 
 namespace Akka.HealthCheck.Hosting.Web.Example;
 
@@ -9,21 +12,28 @@ public static class Program
     {
         var webBuilder = WebApplication.CreateBuilder(args);
 
+        webBuilder.Logging
+            .AddConsole();
+        
         webBuilder.Services
             // Register all of the health check service with IServiceCollection
-            .WithAkkaHealthCheck(HealthCheckType.All) 
-            .AddAkka("actor-system", (builder, serviceProvider) =>
+            .WithAkkaHealthCheck(HealthCheckType.All)
+            .AddHealthChecks();
+        
+        webBuilder.Services.AddAkka("actor-system", (builder, serviceProvider) =>
             {
                 builder
                     .AddHocon("akka.cluster.min-nr-of-members = 1", HoconAddMode.Prepend)
+                    .WithRemoting()
                     .WithClustering()
-                    // Automatically detects which health checks were registered inside the health check middleware and starts them
-                    .WithWebHealthCheck(serviceProvider)
                     .AddStartup((system, _) =>
                     {
                         var cluster = Akka.Cluster.Cluster.Get(system);
                         cluster.Join(cluster.SelfAddress);
                     });
+                
+                // Automatically detects which health checks were registered inside the health check middleware and starts them
+                builder.WithWebHealthCheck(serviceProvider);
             });
 
         var app = webBuilder.Build();
@@ -39,5 +49,4 @@ public static class Program
 
         await app.RunAsync();
     }
-
 }

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.37</AkkaVersion>
-    <AkkaHostingVersion>1.5.37</AkkaHostingVersion>
+    <AkkaVersion>1.5.48</AkkaVersion>
+    <AkkaHostingVersion>1.5.48.1</AkkaHostingVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>


### PR DESCRIPTION
Reproduction for recursion bug issue #300

In the IDE:
1. Open the Akka.HealthCheck.Hosting.Web.Example Program.cs file.
2. Put a break point inside Program.cs line 36.
3. Debug the Akka.HealthCheck.Hosting.Web.Example project.
4. The application will call the `.AddAkka()` delegate function over and over in rapid succession.